### PR TITLE
quit and exit are added by site.py

### DIFF
--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -77,18 +77,6 @@ namespace IronPython.Modules {
             }
         }
 
-        public static object exit {
-            get {
-                return "Use Ctrl-Z plus Return to exit";
-            }
-        }
-
-        public static object quit {
-            get {
-                return "Use Ctrl-Z plus Return to exit";
-            }
-        }
-
         [Documentation("__import__(name) -> module\n\nImport a module.")]
         [LightThrowing]
         public static object __import__(CodeContext/*!*/ context, string name) {


### PR DESCRIPTION
They don't exist if -S is passed, this aligns more with CPython