### PR TITLE
Replace PythonContext.GetContext and PythonContext.GetPythonContext with LanguageContext

### DIFF
--- a/Src/IronPython.Modules/IterTools.cs
+++ b/Src/IronPython.Modules/IterTools.cs
@@ -229,7 +229,7 @@ namespace IronPython.Modules {
                 EnsureNumeric(context, step);
                 _cur = start;
                 _step = step;
-                InnerEnumerator = ObjectYielder(PythonContext.GetContext(context), this, start, step);
+                InnerEnumerator = ObjectYielder(context.LanguageContext, this, start, step);
             }
 
             private static void EnsureNumeric(CodeContext/*!*/ context, object num) {
@@ -384,7 +384,7 @@ namespace IronPython.Modules {
             }
 
             private IEnumerator<object> Yielder(object predicate, IEnumerator iter) {
-                PythonContext pc = PythonContext.GetContext(_context);
+                PythonContext pc = _context.LanguageContext;
 
                 while (MoveNextHelper(iter)) {
                     if (!Converter.ConvertToBoolean(pc.CallSplat(predicate, iter.Current))) {
@@ -448,7 +448,7 @@ namespace IronPython.Modules {
             private object GetKey(object val) {
                 if (_key == null) return val;
 
-                return PythonContext.GetContext(_context).CallSplat(_key, val);
+                return _context.LanguageContext.CallSplat(_key, val);
             }
         }
 
@@ -473,7 +473,7 @@ namespace IronPython.Modules {
             private bool ShouldYield(object predicate, object current) {
                 if (predicate == null) return PythonOps.IsTrue(current);
 
-                return Converter.ConvertToBoolean(PythonContext.GetContext(_context).CallSplat(predicate, current));
+                return Converter.ConvertToBoolean(_context.LanguageContext.CallSplat(predicate, current));
             }
         }
 
@@ -498,7 +498,7 @@ namespace IronPython.Modules {
                 if (predicate == null) return !PythonOps.IsTrue(current);
 
                 return !Converter.ConvertToBoolean(
-                    PythonContext.GetContext(_context).CallSplat(predicate, current)
+                    _context.LanguageContext.CallSplat(predicate, current)
                 );
             }
         }
@@ -534,7 +534,7 @@ namespace IronPython.Modules {
                     if (_function == null) {
                         return PythonTuple.MakeTuple(args);
                     } else {
-                        return PythonContext.GetContext(_context).CallSplat(_function, args);
+                        return _context.LanguageContext.CallSplat(_function, args);
                     }
                 }
             }
@@ -1082,7 +1082,7 @@ namespace IronPython.Modules {
             }
 
             private IEnumerator<object> Yielder(CodeContext context, object function, IEnumerator iter) {
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
 
                 while (MoveNextHelper(iter)) {
                     PythonTuple args = iter.Current as PythonTuple;
@@ -1115,7 +1115,7 @@ namespace IronPython.Modules {
             private IEnumerator<object> Yielder(object predicate, IEnumerator iter) {
                 while (MoveNextHelper(iter)) {
                     if(!Converter.ConvertToBoolean(
-                        PythonContext.GetContext(_context).CallSplat(predicate, iter.Current)
+                        _context.LanguageContext.CallSplat(predicate, iter.Current)
                     )) {
                         break;
                     }

--- a/Src/IronPython.Modules/ModuleOps.cs
+++ b/Src/IronPython.Modules/ModuleOps.cs
@@ -191,7 +191,7 @@ namespace IronPython.Modules {
         }
 
         public static void CallbackException(Exception e, CodeContext/*!*/ context) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             object stderr = pc.SystemStandardError;
             PythonOps.PrintWithDest(context, stderr, pc.FormatException(e));
         }

--- a/Src/IronPython.Modules/_bisect.cs
+++ b/Src/IronPython.Modules/_bisect.cs
@@ -39,7 +39,7 @@ common approach.
             if (hi == -1) {
                 hi = list.Count;
             }
-            IComparer comparer = PythonContext.GetContext(context).GetComparer(null, GetComparisonType(list));
+            IComparer comparer = context.LanguageContext.GetComparer(null, GetComparisonType(list));
             while (lo < hi) {
                 mid = (int)(((long)lo + hi) / 2);
                 litem = list[mid];
@@ -62,7 +62,7 @@ common approach.
             if (hi == -1) {
                 hi = PythonOps.Length(list);
             }
-            IComparer comparer = PythonContext.GetContext(context).GetComparer(null, GetComparisonType(context, list));
+            IComparer comparer = context.LanguageContext.GetComparer(null, GetComparisonType(context, list));
             while (lo < hi) {
                 mid = (int)(((long)lo + hi) / 2);
                 litem = PythonOps.GetIndex(context, list, mid);
@@ -85,7 +85,7 @@ common approach.
             if (hi == -1) {
                 hi = list.Count;
             }
-            IComparer comparer = PythonContext.GetContext(context).GetComparer(null, GetComparisonType(list));
+            IComparer comparer = context.LanguageContext.GetComparer(null, GetComparisonType(list));
             while (lo < hi) {
                 mid = (int)(((long)lo + hi) / 2);
                 litem = list[mid];
@@ -109,7 +109,7 @@ common approach.
                 hi = PythonOps.Length(list);
             }
 
-            IComparer comparer = PythonContext.GetContext(context).GetComparer(null, GetComparisonType(context, list));
+            IComparer comparer = context.LanguageContext.GetComparer(null, GetComparisonType(context, list));
             while (lo < hi) {
                 mid = (int)(((long)lo + hi) / 2);
                 litem = PythonOps.GetIndex(context, list, mid);

--- a/Src/IronPython.Modules/_bytesio.cs
+++ b/Src/IronPython.Modules/_bytesio.cs
@@ -309,7 +309,7 @@ namespace IronPython.Modules {
 
                 int posInt = (int)pos;
                 if (whence is double || whence is Extensible<double>) {
-                    if (PythonContext.GetContext(context).PythonOptions.Python30) {
+                    if (context.LanguageContext.PythonOptions.Python30) {
                         throw PythonOps.TypeError("integer argument expected, got float");
                     } else {
                         PythonOps.Warn(context, PythonExceptions.DeprecationWarning, "integer argument expected, got float");

--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -172,7 +172,7 @@ namespace IronPython.Modules {
         }
 
         public static object decode(CodeContext/*!*/ context, object obj) {
-            PythonTuple t = lookup(context, PythonContext.GetContext(context).GetDefaultEncodingName());
+            PythonTuple t = lookup(context, context.LanguageContext.GetDefaultEncodingName());
 
             return PythonOps.GetIndex(context, PythonCalls.Call(context, t[DecoderIndex], obj, null), 0);
         }
@@ -190,7 +190,7 @@ namespace IronPython.Modules {
         }
 
         public static object encode(CodeContext/*!*/ context, object obj) {
-            PythonTuple t = lookup(context, PythonContext.GetContext(context).GetDefaultEncodingName());
+            PythonTuple t = lookup(context, context.LanguageContext.GetDefaultEncodingName());
 
             return PythonOps.GetIndex(context, PythonCalls.Call(context, t[EncoderIndex], obj, null), 0);
         }

--- a/Src/IronPython.Modules/_collections.cs
+++ b/Src/IronPython.Modules/_collections.cs
@@ -344,7 +344,7 @@ namespace IronPython.Modules {
                     if (_itemCnt == 0) return;
 
                     // set rot to the appropriate positive int
-                    int rot = PythonContext.GetContext(context).ConvertToInt32(n) % _itemCnt;
+                    int rot = context.LanguageContext.ConvertToInt32(n) % _itemCnt;
                     rot = rot % _itemCnt;
                     if (rot == 0) return; // no need to rotate if we'll end back up where we started
                     if (rot < 0) rot += _itemCnt;
@@ -683,7 +683,7 @@ namespace IronPython.Modules {
                     throw PythonOps.IndexError("deque index out of range");
                 }
 
-                int intIndex = PythonContext.GetContext(context).ConvertToInt32(index);
+                int intIndex = context.LanguageContext.ConvertToInt32(index);
                 if (intIndex >= 0) {
                     if (intIndex >= _itemCnt) {
                         throw PythonOps.IndexError("deque index out of range");
@@ -944,7 +944,7 @@ namespace IronPython.Modules {
             public defaultdict(CodeContext/*!*/ context) {
                 _missingSite = CallSite<Func<CallSite, CodeContext, object, object>>.Create(
                     new PythonInvokeBinder(
-                        PythonContext.GetContext(context),
+                        context.LanguageContext,
                         new CallSignature(0)
                     )
                 );

--- a/Src/IronPython.Modules/_csv.cs
+++ b/Src/IronPython.Modules/_csv.cs
@@ -48,7 +48,7 @@ namespace IronPython.Modules
 
         public static int field_size_limit(CodeContext /*!*/ context, int new_limit)
         {
-            PythonContext ctx = PythonContext.GetContext(context);
+            PythonContext ctx = context.LanguageContext;
             int old_limit = (int)ctx.GetModuleState(_fieldSizeLimitKey);
             ctx.SetModuleState(_fieldSizeLimitKey, new_limit);
             return old_limit;
@@ -56,7 +56,7 @@ namespace IronPython.Modules
 
         public static int field_size_limit(CodeContext/*!*/ context)
         {
-            return (int)PythonContext.GetContext(context).
+            return (int)context.LanguageContext.
                 GetModuleState(_fieldSizeLimitKey);
         }
 
@@ -107,7 +107,7 @@ dialect = csv.register_dialect(name, dialect)")]
         /// <returns></returns>
         private static DialectRegistry GetDialects(CodeContext/*!*/ context)
         {
-            PythonContext ctx = PythonContext.GetContext(context);
+            PythonContext ctx = context.LanguageContext;
             if (!ctx.HasModuleState(_dialectRegistryKey))
             {
                 ctx.SetModuleState(_dialectRegistryKey,
@@ -119,7 +119,7 @@ dialect = csv.register_dialect(name, dialect)")]
 
         private static int GetFieldSizeLimit(CodeContext/*!*/ context)
         {
-            PythonContext ctx = PythonContext.GetContext(context);
+            PythonContext ctx = context.LanguageContext;
             if (!ctx.HasModuleState(_fieldSizeLimitKey))
             {
                 ctx.SetModuleState(_fieldSizeLimitKey, FieldSizeLimit);

--- a/Src/IronPython.Modules/_ctypes/CFuncPtr.cs
+++ b/Src/IronPython.Modules/_ctypes/CFuncPtr.cs
@@ -361,7 +361,7 @@ namespace IronPython.Modules {
                 }
 
                 private Expression AddReturnChecks(CodeContext context, DynamicMetaObject[] args, Expression res) {
-                    PythonContext ctx = PythonContext.GetContext(context); 
+                    PythonContext ctx = context.LanguageContext; 
                     
                     object resType = Value.Getrestype();
                     if (resType != null) {

--- a/Src/IronPython.Modules/_ctypes/CFuncPtrType.cs
+++ b/Src/IronPython.Modules/_ctypes/CFuncPtrType.cs
@@ -215,7 +215,7 @@ namespace IronPython.Modules {
 
                 DynamicMethod dm = new DynamicMethod("ReverseInteropInvoker", retType, ArrayUtils.RemoveLast(sigTypes), DynamicModule);
                 ILGenerator ilGen = dm.GetILGenerator();
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
 
                 Type callDelegateSiteType = CompilerHelpers.MakeCallSiteDelegateType(callSiteType);
                 CallSite site = CallSite.Create(callDelegateSiteType, pc.Invoke(new CallSignature(_argtypes.Length)));

--- a/Src/IronPython.Modules/_ctypes/_ctypes.cs
+++ b/Src/IronPython.Modules/_ctypes/_ctypes.cs
@@ -207,7 +207,7 @@ namespace IronPython.Modules {
         /// Returns a new type which represents a pointer given the existing type.
         /// </summary>
         public static PythonType POINTER(CodeContext/*!*/ context, PythonType type) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             PythonDictionary dict = (PythonDictionary)pc.GetModuleState(_pointerTypeCacheKey);
 
             lock (dict) {
@@ -237,7 +237,7 @@ namespace IronPython.Modules {
 
         public static PythonType POINTER(CodeContext/*!*/ context, [NotNull]string name) {
             PythonType res = MakePointer(context, name, new PythonDictionary());
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             PythonDictionary dict = (PythonDictionary)pc.GetModuleState(_pointerTypeCacheKey);
 
             lock (dict) {
@@ -438,7 +438,7 @@ namespace IronPython.Modules {
 
         public static PythonTuple/*!*/ set_conversion_mode(CodeContext/*!*/ context, string encoding, string errors) {
             // TODO: Need an atomic update for module state
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             PythonTuple prev = (PythonTuple)pc.GetModuleState(_conversion_mode);
 
             pc.SetModuleState(_conversion_mode, PythonTuple.MakeTuple(encoding, errors));

--- a/Src/IronPython.Modules/_fileio.cs
+++ b/Src/IronPython.Modules/_fileio.cs
@@ -75,7 +75,7 @@ namespace IronPython.Modules {
                     throw PythonOps.ValueError("fd must be >= 0");
                 }
 
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
 
                 PythonFile pf = null;
                 FileIO file = null;
@@ -132,7 +132,7 @@ namespace IronPython.Modules {
                 }
                 _closefd = true;
                 this.name = name;
-                PlatformAdaptationLayer pal = PythonContext.GetContext(context).DomainManager.Platform;
+                PlatformAdaptationLayer pal = context.LanguageContext.DomainManager.Platform;
 
                 switch (StandardizeMode(mode)) {
                     case "r":
@@ -171,7 +171,7 @@ namespace IronPython.Modules {
                         break;
                 }
 
-                _context = PythonContext.GetContext(context);
+                _context = context.LanguageContext;
             }
 
             /// <summary>

--- a/Src/IronPython.Modules/_functools.cs
+++ b/Src/IronPython.Modules/_functools.cs
@@ -235,7 +235,7 @@ namespace IronPython.Modules {
                     Interlocked.CompareExchange(
                         ref _splatSite,
                         CallSite<Func<CallSite, CodeContext, object, object[], object>>.Create(
-                            Binders.InvokeSplat(PythonContext.GetContext(_context))
+                            Binders.InvokeSplat(_context.LanguageContext)
                         ),
                         null
                     );
@@ -247,7 +247,7 @@ namespace IronPython.Modules {
                     Interlocked.CompareExchange(
                         ref _dictSite,
                         CallSite<Func<CallSite, CodeContext, object, object[], IDictionary<object, object>, object>>.Create(
-                            Binders.InvokeKeywords(PythonContext.GetContext(_context))
+                            Binders.InvokeKeywords(_context.LanguageContext)
                         ),
                         null
                     );

--- a/Src/IronPython.Modules/_heapq.cs
+++ b/Src/IronPython.Modules/_heapq.cs
@@ -164,7 +164,7 @@ namespace IronPython.Modules {
                 !Object.ReferenceEquals(ret, NotImplementedType.Value)) {
                 return !Converter.ConvertToBoolean(ret);
             } else {
-                return PythonContext.GetContext(context).LessThan(x, y);
+                return context.LanguageContext.LessThan(x, y);
             }
         }
 

--- a/Src/IronPython.Modules/_io.cs
+++ b/Src/IronPython.Modules/_io.cs
@@ -418,7 +418,7 @@ namespace IronPython.Modules {
 
             internal Exception UnsupportedOperation(CodeContext/*!*/ context, string attr) {
                 throw PythonExceptions.CreateThrowable(
-                    (PythonType)PythonContext.GetContext(context).GetModuleState(_unsupportedOperationKey),
+                    (PythonType)context.LanguageContext.GetModuleState(_unsupportedOperationKey),
                     string.Format("{0}.{1} not supported", PythonTypeOps.GetName(this), attr)
                 );
             }

--- a/Src/IronPython.Modules/_locale.cs
+++ b/Src/IronPython.Modules/_locale.cs
@@ -298,13 +298,13 @@ Note: Return value differs from CPython - it is not a string.")]
         }
 
         internal static LocaleInfo/*!*/ GetLocaleInfo(CodeContext/*!*/ context) {
-            EnsureLocaleInitialized(PythonContext.GetContext(context));
+            EnsureLocaleInitialized(context.LanguageContext);
 
-            return (LocaleInfo)PythonContext.GetContext(context).GetModuleState(_localeKey);
+            return (LocaleInfo)context.LanguageContext.GetModuleState(_localeKey);
         }        
 
         private static PythonType _localeerror(CodeContext/*!*/ context) {
-            return (PythonType)PythonContext.GetContext(context).GetModuleState("_localeerror");
+            return (PythonType)context.LanguageContext.GetModuleState("_localeerror");
         }
     }
 }

--- a/Src/IronPython.Modules/_sre.cs
+++ b/Src/IronPython.Modules/_sre.cs
@@ -29,8 +29,8 @@ namespace IronPython.Modules {
         public const int CODESIZE = 2;
 
         public static object getlower(CodeContext/*!*/ context, object val, object encoding) {
-            int encInt = PythonContext.GetContext(context).ConvertToInt32(val);
-            int charVal = PythonContext.GetContext(context).ConvertToInt32(val);
+            int encInt = context.LanguageContext.ConvertToInt32(val);
+            int charVal = context.LanguageContext.ConvertToInt32(val);
 
             if (encInt == (int)PythonRegex.UNICODE) {
                 return (int)Char.ToLower((char)charVal);

--- a/Src/IronPython.Modules/_ssl.cs
+++ b/Src/IronPython.Modules/_ssl.cs
@@ -354,7 +354,7 @@ namespace IronPython.Modules {
         }
 
         internal static PythonType SSLError(CodeContext/*!*/ context) {
-            return (PythonType)PythonContext.GetContext(context).GetModuleState("SSLError");
+            return (PythonType)context.LanguageContext.GetModuleState("SSLError");
         }
 
         public static PythonDictionary _test_decode_cert(CodeContext context, string filename, [DefaultParameterValue(false)]bool complete) {

--- a/Src/IronPython.Modules/_struct.cs
+++ b/Src/IronPython.Modules/_struct.cs
@@ -1101,7 +1101,7 @@ namespace IronPython.Modules {
             }
             float res = BitConverter.ToSingle(bytes, 0);
 
-            if (PythonContext.GetContext(context).FloatFormat == FloatFormat.Unknown) {
+            if (context.LanguageContext.FloatFormat == FloatFormat.Unknown) {
                 if (Single.IsNaN(res) || Single.IsInfinity(res)) {
                     throw PythonOps.ValueError("can't unpack IEEE 754 special value on non-IEEE platform");
                 }
@@ -1192,7 +1192,7 @@ namespace IronPython.Modules {
             }
 
             double res = BitConverter.ToDouble(bytes, 0);
-            if (PythonContext.GetContext(context).DoubleFormat == FloatFormat.Unknown) {
+            if (context.LanguageContext.DoubleFormat == FloatFormat.Unknown) {
                 if (Double.IsNaN(res) || Double.IsInfinity(res)) {
                     throw PythonOps.ValueError("can't unpack IEEE 754 special value on non-IEEE platform");
                 }
@@ -1237,7 +1237,7 @@ namespace IronPython.Modules {
         }
 
         private static Exception Error(CodeContext/*!*/ context, string msg) {
-            return PythonExceptions.CreateThrowable((PythonType)PythonContext.GetContext(context).GetModuleState("structerror"), msg);
+            return PythonExceptions.CreateThrowable((PythonType)context.LanguageContext.GetModuleState("structerror"), msg);
         }
 
         #endregion

--- a/Src/IronPython.Modules/_warnings.cs
+++ b/Src/IronPython.Modules/_warnings.cs
@@ -61,7 +61,7 @@ namespace IronPython.Modules {
         #region Public API
 
         public static void warn(CodeContext context, object message, [DefaultParameterValue(null)]PythonType category, [DefaultParameterValue(1)]int stacklevel) {
-            PythonContext pContext = PythonContext.GetContext(context);
+            PythonContext pContext = context.LanguageContext;
             List argv = pContext.GetSystemStateValue("argv") as List;
 
             if (PythonOps.IsInstance(message, PythonExceptions.Warning)) {
@@ -77,7 +77,7 @@ namespace IronPython.Modules {
             TraceBackFrame caller = null;
             PythonDictionary globals;
             int lineno;
-            if (PythonContext.GetContext(context).PythonOptions.Frames) {
+            if (context.LanguageContext.PythonOptions.Frames) {
                 try {
                     caller = SysModule._getframeImpl(context, stacklevel - 1);
                 } catch (ValueErrorException) { }
@@ -118,7 +118,7 @@ namespace IronPython.Modules {
         }
 
         public static void warn_explicit(CodeContext context, object message, PythonType category, string filename, int lineno, [DefaultParameterValue(null)]string module, [DefaultParameterValue(null)]PythonDictionary registry, [DefaultParameterValue(null)]object module_globals) {
-            PythonContext pContext = PythonContext.GetContext(context);
+            PythonContext pContext = context.LanguageContext;
             PythonDictionary fields = (PythonDictionary)pContext.GetModuleState(_keyFields);
             object warnings = pContext.GetWarningsModule();
             PythonExceptions.BaseException msg;
@@ -254,7 +254,7 @@ namespace IronPython.Modules {
 
             try {
                 if (file == null) {
-                    PythonContext pContext = PythonContext.GetContext(context);
+                    PythonContext pContext = context.LanguageContext;
                     PythonFile stderr = pContext.GetSystemStateValue("stderr") as PythonFile;
                     if (stderr != null) {
                         stderr.write(text);

--- a/Src/IronPython.Modules/_weakref.cs
+++ b/Src/IronPython.Modules/_weakref.cs
@@ -41,11 +41,11 @@ namespace IronPython.Modules {
         }
 
         public static int getweakrefcount(CodeContext context, object @object) {
-            return @ref.GetWeakRefCount(PythonContext.GetContext(context), @object);
+            return @ref.GetWeakRefCount(context.LanguageContext, @object);
         }
 
         public static List getweakrefs(CodeContext context, object @object) {
-            return @ref.GetWeakRefs(PythonContext.GetContext(context), @object);
+            return @ref.GetWeakRefs(context.LanguageContext, @object);
         }
 
         public static object proxy(CodeContext context, object @object) {
@@ -81,7 +81,7 @@ namespace IronPython.Modules {
 
             #region Python Constructors
             public static object __new__(CodeContext context, PythonType cls, object @object) {
-                IWeakReferenceable iwr = ConvertToWeakReferenceable(PythonContext.GetContext(context), @object);
+                IWeakReferenceable iwr = ConvertToWeakReferenceable(context.LanguageContext, @object);
 
                 if (cls == DynamicHelpers.GetPythonTypeFromType(typeof(@ref))) {
                     WeakRefTracker wrt = iwr.GetWeakRef();
@@ -217,7 +217,7 @@ namespace IronPython.Modules {
                 if (!_fHasHash) {
                     object refObj = _target.Target;
                     if (refObj == null) throw PythonOps.TypeError("weak object has gone away");
-                    _hashVal = PythonContext.GetContext(context).EqualityComparerNonGeneric.GetHashCode(refObj);
+                    _hashVal = context.LanguageContext.EqualityComparerNonGeneric.GetHashCode(refObj);
                     _fHasHash = true;
                 }
                 GC.KeepAlive(this);
@@ -304,7 +304,7 @@ namespace IronPython.Modules {
 
             #region Python Constructors
             internal static object MakeNew(CodeContext/*!*/ context, object @object, object callback) {
-                IWeakReferenceable iwr = ConvertToWeakReferenceable(PythonContext.GetContext(context), @object);
+                IWeakReferenceable iwr = ConvertToWeakReferenceable(context.LanguageContext, @object);
 
                 if (callback == null) {
                     WeakRefTracker wrt = iwr.GetWeakRef();
@@ -324,7 +324,7 @@ namespace IronPython.Modules {
             #region Constructors
 
             private weakproxy(CodeContext/*!*/ context, object target, object callback) {
-                WeakRefHelpers.InitializeWeakRef(PythonContext.GetContext(context), this, target, callback);
+                WeakRefHelpers.InitializeWeakRef(context.LanguageContext, this, target, callback);
                 _target = new WeakHandle(target, false);
                 _context = context;
             }
@@ -563,7 +563,7 @@ namespace IronPython.Modules {
             #region Python Constructors
 
             internal static object MakeNew(CodeContext/*!*/ context, object @object, object callback) {
-                IWeakReferenceable iwr = ConvertToWeakReferenceable(PythonContext.GetContext(context), @object);
+                IWeakReferenceable iwr = ConvertToWeakReferenceable(context.LanguageContext, @object);
 
                 if (callback == null) {
                     WeakRefTracker wrt = iwr.GetWeakRef();
@@ -586,7 +586,7 @@ namespace IronPython.Modules {
             #region Constructors
 
             private weakcallableproxy(CodeContext context, object target, object callback) {
-                WeakRefHelpers.InitializeWeakRef(PythonContext.GetContext(context), this, target, callback);
+                WeakRefHelpers.InitializeWeakRef(context.LanguageContext, this, target, callback);
                 _target = new WeakHandle(target, false);
                 _context = context;
             }
@@ -689,7 +689,7 @@ namespace IronPython.Modules {
 
             [SpecialName]
             public object Call(CodeContext/*!*/ context, params object[] args) {
-                return PythonContext.GetContext(context).CallSplat(GetObject(), args);
+                return context.LanguageContext.CallSplat(GetObject(), args);
             }
                         
             [SpecialName]

--- a/Src/IronPython.Modules/_weakref.cs
+++ b/Src/IronPython.Modules/_weakref.cs
@@ -116,7 +116,7 @@ namespace IronPython.Modules {
 
             public @ref(CodeContext context, object @object, object callback) {
                 _context = context;
-                WeakRefTracker wrt = WeakRefHelpers.InitializeWeakRef(_context.GetPythonContext(), this, @object, callback);
+                WeakRefTracker wrt = WeakRefHelpers.InitializeWeakRef(_context.LanguageContext, this, @object, callback);
 
                 _target = new WeakHandle(@object, false);
                 _targetId = wrt.TargetId;
@@ -126,7 +126,7 @@ namespace IronPython.Modules {
             #region Finalizer
             ~@ref() {
                 IWeakReferenceable iwr;
-                if (_context.GetPythonContext().TryConvertToWeakReferenceable(_target.Target, out iwr))
+                if (_context.LanguageContext.TryConvertToWeakReferenceable(_target.Target, out iwr))
                 {
                     WeakRefTracker wrt = iwr.GetWeakRef();
                     if (wrt != null) {
@@ -334,7 +334,7 @@ namespace IronPython.Modules {
             ~weakproxy() {
                 // remove our self from the chain...
                 IWeakReferenceable iwr;
-                if (_context.GetPythonContext().TryConvertToWeakReferenceable(_target.Target, out iwr)) {
+                if (_context.LanguageContext.TryConvertToWeakReferenceable(_target.Target, out iwr)) {
                     WeakRefTracker wrt = iwr.GetWeakRef();
                     wrt.RemoveHandler(this);
                 }
@@ -598,7 +598,7 @@ namespace IronPython.Modules {
             ~weakcallableproxy() {
                 // remove our self from the chain...
                 IWeakReferenceable iwr;
-                if (_context.GetPythonContext().TryConvertToWeakReferenceable(_target.Target, out iwr))
+                if (_context.LanguageContext.TryConvertToWeakReferenceable(_target.Target, out iwr))
                 {
                     WeakRefTracker wrt = iwr.GetWeakRef();
                     wrt.RemoveHandler(this);

--- a/Src/IronPython.Modules/binascii.cs
+++ b/Src/IronPython.Modules/binascii.cs
@@ -37,10 +37,10 @@ namespace IronPython.Modules {
         private static readonly object _IncompleteKey = new object();
 
         private static Exception Error(CodeContext/*!*/ context, params object[] args) {
-            return PythonExceptions.CreateThrowable((PythonType)PythonContext.GetContext(context).GetModuleState(_ErrorKey), args);
+            return PythonExceptions.CreateThrowable((PythonType)context.LanguageContext.GetModuleState(_ErrorKey), args);
         }
         private static Exception Incomplete(CodeContext/*!*/ context, params object[] args) {
-            return PythonExceptions.CreateThrowable((PythonType)PythonContext.GetContext(context).GetModuleState(_IncompleteKey), args);
+            return PythonExceptions.CreateThrowable((PythonType)context.LanguageContext.GetModuleState(_IncompleteKey), args);
         }
 
         [SpecialName]

--- a/Src/IronPython.Modules/bz2/BZ2File.cs
+++ b/Src/IronPython.Modules/bz2/BZ2File.cs
@@ -52,7 +52,7 @@ is given, must be a number between 1 and 9.
                 [DefaultParameterValue(0)]int buffering,
                 [DefaultParameterValue(DEFAULT_COMPRESSLEVEL)]int compresslevel) {
 
-                var pythonContext = PythonContext.GetContext(context);
+                var pythonContext = context.LanguageContext;
 
                 this.buffering = buffering;
                 this.compresslevel = compresslevel;

--- a/Src/IronPython.Modules/cPickle.cs
+++ b/Src/IronPython.Modules/cPickle.cs
@@ -653,7 +653,7 @@ namespace IronPython.Modules {
 
             private bool TrySavePersistId(CodeContext context, object obj) {
                 Debug.Assert(_persist_id != null);
-                string res = Converter.ConvertToString(PythonContext.GetContext(context).CallSplat(_persist_id, obj));
+                string res = Converter.ConvertToString(context.LanguageContext.CallSplat(_persist_id, obj));
                 if (res != null) {
                     SavePersId(context, res);
                     return true;
@@ -1259,7 +1259,7 @@ namespace IronPython.Modules {
                 if (value is int) {
                     return IsUInt8((int)value);
                 }
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
 
                 return pc.LessThanOrEqual(0, value) && pc.LessThan(value, 1 << 8);
             }
@@ -1279,7 +1279,7 @@ namespace IronPython.Modules {
                 if (value is int) {
                     return IsUInt16((int)value);
                 }
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
 
                 return pc.LessThanOrEqual(1 << 8, value) && pc.LessThan(value, 1 << 16);
             }
@@ -1296,7 +1296,7 @@ namespace IronPython.Modules {
             /// Return true if value is appropriate for formatting in pickle int4 format.
             /// </summary>
             private static bool IsInt32(CodeContext/*!*/ context, object value) {
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
 
                 return pc.LessThanOrEqual(Int32.MinValue, value) && pc.LessThanOrEqual(value, Int32.MaxValue);
             }
@@ -1345,7 +1345,7 @@ namespace IronPython.Modules {
 
             private void WriteGetOrPut(CodeContext context, bool isGet, PythonTuple tup) {
                 object index = tup[0];
-                Debug.Assert(PythonContext.GetContext(context).GreaterThanOrEqual(index, 0));
+                Debug.Assert(context.LanguageContext.GreaterThanOrEqual(index, 0));
                 if (_protocol < 1) {
                     Write(context, isGet ? Opcode.Get : Opcode.Put);
                     WriteIntAsString(context, index);
@@ -2001,7 +2001,7 @@ namespace IronPython.Modules {
             private void LoadBinPersid(CodeContext/*!*/ context) {
                 if (_pers_loader == null) throw CannotUnpickle(context, "cannot unpickle binary persistent ID w/o persistent_load");
 
-                _stack.Add(PythonContext.GetContext(context).CallSplat(_pers_loader, PopStack()));
+                _stack.Add(context.LanguageContext.CallSplat(_pers_loader, PopStack()));
             }
 
             private void LoadBinPut(CodeContext/*!*/ context) {
@@ -2243,7 +2243,7 @@ namespace IronPython.Modules {
                 if (_pers_loader == null) {
                     throw CannotUnpickle(context, "A load persistent ID instruction is present but no persistent_load function is available");
                 }
-                _stack.Add(PythonContext.GetContext(context).CallSplat(_pers_loader, ReadLineNoNewline(context)));
+                _stack.Add(context.LanguageContext.CallSplat(_pers_loader, ReadLineNoNewline(context)));
             }
 
             private void LoadPop(CodeContext/*!*/ context) {
@@ -2355,19 +2355,19 @@ namespace IronPython.Modules {
         #endregion
 
         private static PythonType PicklingError(CodeContext/*!*/ context) {
-            return (PythonType)PythonContext.GetContext(context).GetModuleState("PicklingError");
+            return (PythonType)context.LanguageContext.GetModuleState("PicklingError");
         }
 
         private static PythonType PickleError(CodeContext/*!*/ context) {
-            return (PythonType)PythonContext.GetContext(context).GetModuleState("PickleError");
+            return (PythonType)context.LanguageContext.GetModuleState("PickleError");
         }
 
         private static PythonType UnpicklingError(CodeContext/*!*/ context) {
-            return (PythonType)PythonContext.GetContext(context).GetModuleState("UnpicklingError");
+            return (PythonType)context.LanguageContext.GetModuleState("UnpicklingError");
         }
 
         private static PythonType BadPickleGet(CodeContext/*!*/ context) {
-            return (PythonType)PythonContext.GetContext(context).GetModuleState("BadPickleGet");
+            return (PythonType)context.LanguageContext.GetModuleState("BadPickleGet");
         }
 
         class ReferenceEqualityComparer : IEqualityComparer<object> {

--- a/Src/IronPython.Modules/copy_reg.cs
+++ b/Src/IronPython.Modules/copy_reg.cs
@@ -43,25 +43,25 @@ namespace IronPython.Modules {
         internal static PythonDictionary GetDispatchTable(CodeContext/*!*/ context) {
             EnsureModuleInitialized(context);
 
-            return (PythonDictionary)PythonContext.GetContext(context).GetModuleState(_dispatchTableKey);
+            return (PythonDictionary)context.LanguageContext.GetModuleState(_dispatchTableKey);
         }
 
         internal static PythonDictionary GetExtensionRegistry(CodeContext/*!*/ context) {
             EnsureModuleInitialized(context);
 
-            return (PythonDictionary)PythonContext.GetContext(context).GetModuleState(_extensionRegistryKey);
+            return (PythonDictionary)context.LanguageContext.GetModuleState(_extensionRegistryKey);
         }
 
         internal static PythonDictionary GetInvertedRegistry(CodeContext/*!*/ context) {
             EnsureModuleInitialized(context);
 
-            return (PythonDictionary)PythonContext.GetContext(context).GetModuleState(_invertedRegistryKey);
+            return (PythonDictionary)context.LanguageContext.GetModuleState(_invertedRegistryKey);
         }
 
         internal static PythonDictionary GetExtensionCache(CodeContext/*!*/ context) {
             EnsureModuleInitialized(context);
 
-            return (PythonDictionary)PythonContext.GetContext(context).GetModuleState(_extensionCacheKey);
+            return (PythonDictionary)context.LanguageContext.GetModuleState(_extensionCacheKey);
         }
 
         #region Public API
@@ -202,7 +202,7 @@ namespace IronPython.Modules {
         /// </summary>
         private static int GetCode(CodeContext/*!*/ context, object value) {
             try {
-                int intValue = PythonContext.GetContext(context).ConvertToInt32(value);
+                int intValue = context.LanguageContext.ConvertToInt32(value);
                 if (intValue > 0) return intValue;
                 // fall through and throw below
             } catch (OverflowException) {
@@ -214,7 +214,7 @@ namespace IronPython.Modules {
         #endregion
 
         private static void EnsureModuleInitialized(CodeContext context) {
-            if (!PythonContext.GetContext(context).HasModuleState(_dispatchTableKey)) {
+            if (!context.LanguageContext.HasModuleState(_dispatchTableKey)) {
                 Importer.ImportBuiltin(context, "copy_reg");
             }
         }

--- a/Src/IronPython.Modules/gc.cs
+++ b/Src/IronPython.Modules/gc.cs
@@ -58,7 +58,7 @@ namespace IronPython.Modules {
         }
 
         public static int collect(CodeContext context, int generation) {
-            return PythonContext.GetContext(context).Collect(generation);
+            return context.LanguageContext.Collect(generation);
         }
 
         public static int collect(CodeContext context) {
@@ -121,11 +121,11 @@ namespace IronPython.Modules {
         }
 
         private static PythonTuple GetThresholds(CodeContext/*!*/ context) {
-            return (PythonTuple)PythonContext.GetContext(context).GetModuleState(_threadholdKey);
+            return (PythonTuple)context.LanguageContext.GetModuleState(_threadholdKey);
         }
 
         private static void SetThresholds(CodeContext/*!*/ context, PythonTuple thresholds) {
-            PythonContext.GetContext(context).SetModuleState(_threadholdKey, thresholds);
+            context.LanguageContext.SetModuleState(_threadholdKey, thresholds);
         }
     }
 }

--- a/Src/IronPython.Modules/mmap.cs
+++ b/Src/IronPython.Modules/mmap.cs
@@ -71,14 +71,14 @@ namespace IronPython.Modules {
 
         private static Exception Error(CodeContext/*!*/ context, string/*!*/ message) {
             return PythonExceptions.CreateThrowable(
-                (PythonType)PythonContext.GetContext(context).GetModuleState(_mmapErrorKey),
+                (PythonType)context.LanguageContext.GetModuleState(_mmapErrorKey),
                 message
             );
         }
 
         private static Exception Error(CodeContext/*!*/ context, int errno, string/*!*/ message) {
             return PythonExceptions.CreateThrowable(
-                (PythonType)PythonContext.GetContext(context).GetModuleState(_mmapErrorKey),
+                (PythonType)context.LanguageContext.GetModuleState(_mmapErrorKey),
                 errno,
                 message
             );
@@ -167,7 +167,7 @@ namespace IronPython.Modules {
                     _offset = offset;
 
                     PythonFile file;
-                    PythonContext pContext = PythonContext.GetContext(context);
+                    PythonContext pContext = context.LanguageContext;
                     if (!pContext.FileManager.TryGetFileFromId(pContext, fileno, out file)) {
                         throw Error(context, PythonExceptions._WindowsError.ERROR_INVALID_BLOCK, "Bad file descriptor");
                     }

--- a/Src/IronPython.Modules/nt.cs
+++ b/Src/IronPython.Modules/nt.cs
@@ -128,7 +128,7 @@ namespace IronPython.Modules {
         }
 #endif
         public static void close(CodeContext/*!*/ context, int fd) {
-            PythonContext pythonContext = PythonContext.GetContext(context);
+            PythonContext pythonContext = context.LanguageContext;
             PythonFileManager fileManager = pythonContext.FileManager;
             PythonFile file;
             if (fileManager.TryGetFileFromId(pythonContext, fd, out file)) {
@@ -152,7 +152,7 @@ namespace IronPython.Modules {
             }
         }
         private static bool IsValidFd(CodeContext/*!*/ context, int fd) {
-            PythonContext pythonContext = PythonContext.GetContext(context);
+            PythonContext pythonContext = context.LanguageContext;
             PythonFile file;
             if (pythonContext.FileManager.TryGetFileFromId(pythonContext, fd, out file)) {
                 return true;
@@ -168,7 +168,7 @@ namespace IronPython.Modules {
         }
 
         public static int dup(CodeContext/*!*/ context, int fd) {
-            PythonContext pythonContext = PythonContext.GetContext(context);
+            PythonContext pythonContext = context.LanguageContext;
             PythonFile file;
             if (pythonContext.FileManager.TryGetFileFromId(pythonContext, fd, out file)) {
                 return pythonContext.FileManager.AddToStrongMapping(file);
@@ -183,7 +183,7 @@ namespace IronPython.Modules {
 
 
         public static int dup2(CodeContext/*!*/ context, int fd, int fd2) {
-            PythonContext pythonContext = PythonContext.GetContext(context);
+            PythonContext pythonContext = context.LanguageContext;
             PythonFile file;
 
             if (!IsValidFd(context, fd)) {
@@ -231,7 +231,7 @@ namespace IronPython.Modules {
         public static readonly PythonType error = Builtin.OSError;
 
         public static void _exit(CodeContext/*!*/ context, int code) {
-            PythonContext.GetContext(context).DomainManager.Platform.TerminateScriptExecution(code);
+            context.LanguageContext.DomainManager.Platform.TerminateScriptExecution(code);
         }
 
         public static object fdopen(CodeContext/*!*/ context, int fd) {
@@ -246,7 +246,7 @@ namespace IronPython.Modules {
             // check for a valid file mode...
             PythonFile.ValidateMode(mode);
 
-            PythonContext pythonContext = PythonContext.GetContext(context);
+            PythonContext pythonContext = context.LanguageContext;
             PythonFile pf;
             if (pythonContext.FileManager.TryGetFileFromId(pythonContext, fd, out pf)) {
                 return pf;
@@ -262,7 +262,7 @@ namespace IronPython.Modules {
 
         [LightThrowing]
         public static object fstat(CodeContext/*!*/ context, int fd) {
-            PythonContext pythonContext = PythonContext.GetContext(context);
+            PythonContext pythonContext = context.LanguageContext;
             PythonFile pf = pythonContext.FileManager.GetFileFromId(pythonContext, fd);
             if (pf.IsConsole) {
                 return new stat_result(8192);
@@ -271,7 +271,7 @@ namespace IronPython.Modules {
         }
 
         public static void fsync(CodeContext context, int fd) {
-            PythonContext pythonContext = PythonContext.GetContext(context);
+            PythonContext pythonContext = context.LanguageContext;
             PythonFile pf = pythonContext.FileManager.GetFileFromId(pythonContext, fd);
             if (!pf.IsOutput) {
                 throw PythonExceptions.CreateThrowable(PythonExceptions.OSError, 9, "Bad file descriptor");
@@ -467,7 +467,7 @@ namespace IronPython.Modules {
                     mode2 += "b";
                 }
 
-                return PythonContext.GetContext(context).FileManager.AddToStrongMapping(PythonFile.Create(context, fs, filename, mode2));
+                return context.LanguageContext.FileManager.AddToStrongMapping(PythonFile.Create(context, fs, filename, mode2));
             } catch (Exception e) {
                 throw ToPythonException(e, filename);
             }
@@ -606,7 +606,7 @@ namespace IronPython.Modules {
             }
 
             try {
-                PythonContext pythonContext = PythonContext.GetContext(context);
+                PythonContext pythonContext = context.LanguageContext;
                 PythonFile pf = pythonContext.FileManager.GetFileFromId(pythonContext, fd);
                 return pf.read(buffersize);
             } catch (Exception e) {
@@ -1519,7 +1519,7 @@ namespace IronPython.Modules {
 
         public static int umask(CodeContext/*!*/ context, int mask) {
             mask &= 0x180;
-            object oldMask = PythonContext.GetContext(context).GetSetModuleState(_umaskKey, mask);
+            object oldMask = context.LanguageContext.GetSetModuleState(_umaskKey, mask);
             if (oldMask == null) {
                 return 0;
             } else {
@@ -1583,7 +1583,7 @@ namespace IronPython.Modules {
 
         public static int write(CodeContext/*!*/ context, int fd, [BytesConversion]string text) {
             try {
-                PythonContext pythonContext = PythonContext.GetContext(context);
+                PythonContext pythonContext = context.LanguageContext;
                 PythonFile pf = pythonContext.FileManager.GetFileFromId(pythonContext, fd);
                 pf.write(text);
                 return text.Length;
@@ -1759,8 +1759,8 @@ are defined in the signal module.")]
             private Process _process;
 
             internal POpenFile(CodeContext/*!*/ context, string command, Process process, Stream stream, string mode) 
-                : base(PythonContext.GetContext(context)) {
-                __init__(stream, PythonContext.GetContext(context).DefaultEncoding, command, mode);
+                : base(context.LanguageContext) {
+                __init__(stream, context.LanguageContext.DefaultEncoding, command, mode);
                 this._process = process;
             }
 

--- a/Src/IronPython.Modules/operator.cs
+++ b/Src/IronPython.Modules/operator.cs
@@ -130,27 +130,27 @@ namespace IronPython.Modules {
         }
         
         public static object lt(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.LessThan, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.LessThan, a, b);
         }
 
         public static object le(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.LessThanOrEqual, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.LessThanOrEqual, a, b);
         }
 
         public static object eq(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.Equal, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.Equal, a, b);
         }
 
         public static object ne(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.NotEqual, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.NotEqual, a, b);
         }
 
         public static object ge(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.GreaterThanOrEqual, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.GreaterThanOrEqual, a, b);
         }
 
         public static object gt(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.GreaterThan, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.GreaterThan, a, b);
         }
 
         public static object __lt__(CodeContext/*!*/ context, object a, object b) {
@@ -206,7 +206,7 @@ namespace IronPython.Modules {
         }
 
         public static object add(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.Add, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.Add, a, b);
         }
 
         public static object __add__(CodeContext/*!*/ context, object a, object b) {
@@ -214,7 +214,7 @@ namespace IronPython.Modules {
         }
 
         public static object and_(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.BitwiseAnd, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.BitwiseAnd, a, b);
         }
 
         public static object __and__(CodeContext/*!*/ context, object a, object b) {
@@ -222,7 +222,7 @@ namespace IronPython.Modules {
         }
 
         public static object div(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.Divide, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.Divide, a, b);
         }
 
         public static object __div__(CodeContext/*!*/ context, object a, object b) {
@@ -230,7 +230,7 @@ namespace IronPython.Modules {
         }
 
         public static object floordiv(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.FloorDivide, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.FloorDivide, a, b);
         }
 
         public static object __floordiv__(CodeContext/*!*/ context, object a, object b) {
@@ -254,7 +254,7 @@ namespace IronPython.Modules {
         }
 
         public static object lshift(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.LeftShift, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.LeftShift, a, b);
         }
 
         public static object __lshift__(CodeContext/*!*/ context, object a, object b) {
@@ -262,7 +262,7 @@ namespace IronPython.Modules {
         }
 
         public static object mod(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.Mod, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.Mod, a, b);
         }
 
         public static object __mod__(CodeContext/*!*/ context, object a, object b) {
@@ -270,7 +270,7 @@ namespace IronPython.Modules {
         }
 
         public static object mul(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.Multiply, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.Multiply, a, b);
         }
 
         public static object __mul__(CodeContext/*!*/ context, object a, object b) {
@@ -286,7 +286,7 @@ namespace IronPython.Modules {
         }
 
         public static object or_(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.BitwiseOr, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.BitwiseOr, a, b);
         }
 
         public static object __or__(CodeContext/*!*/ context, object a, object b) {
@@ -302,7 +302,7 @@ namespace IronPython.Modules {
         }
 
         public static object pow(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.Power, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.Power, a, b);
         }
 
         public static object __pow__(CodeContext/*!*/ context, object a, object b) {
@@ -310,7 +310,7 @@ namespace IronPython.Modules {
         }
 
         public static object rshift(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.RightShift, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.RightShift, a, b);
         }
 
         public static object __rshift__(CodeContext/*!*/ context, object a, object b) {
@@ -318,7 +318,7 @@ namespace IronPython.Modules {
         }
 
         public static object sub(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.Subtract, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.Subtract, a, b);
         }
 
         public static object __sub__(CodeContext/*!*/ context, object a, object b) {
@@ -326,7 +326,7 @@ namespace IronPython.Modules {
         }
 
         public static object truediv(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.TrueDivide, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.TrueDivide, a, b);
         }
 
         public static object __truediv__(CodeContext/*!*/ context, object a, object b) {
@@ -334,7 +334,7 @@ namespace IronPython.Modules {
         }
 
         public static object xor(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.ExclusiveOr, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.ExclusiveOr, a, b);
         }
 
         public static object __xor__(CodeContext/*!*/ context, object a, object b) {
@@ -344,7 +344,7 @@ namespace IronPython.Modules {
         public static object concat(CodeContext/*!*/ context, object a, object b) {
             TestBothSequence(a, b);
 
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.Add, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.Add, a, b);
         }
 
         public static object __concat__(CodeContext/*!*/ context, object a, object b) {
@@ -352,7 +352,7 @@ namespace IronPython.Modules {
         }
 
         public static bool contains(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Contains(b, a);
+            return context.LanguageContext.Contains(b, a);
         }
 
         public static bool __contains__(CodeContext/*!*/ context, object a, object b) {
@@ -371,7 +371,7 @@ namespace IronPython.Modules {
         }
 
         public static void delitem(CodeContext/*!*/ context, object a, object b) {
-            PythonContext.GetContext(context).DelIndex(a, b);
+            context.LanguageContext.DelIndex(a, b);
         }
 
         public static void __delitem__(CodeContext/*!*/ context, object a, object b) {
@@ -381,7 +381,7 @@ namespace IronPython.Modules {
         public static void delslice(CodeContext/*!*/ context, object a, object b, object c) {
             MakeSlice(b, c);
 
-            PythonContext.GetContext(context).DelSlice(a, b, c);            
+            context.LanguageContext.DelSlice(a, b, c);            
         }
 
         public static void __delslice__(CodeContext/*!*/ context, object a, object b, object c) {
@@ -428,7 +428,7 @@ namespace IronPython.Modules {
                 throw PythonOps.TypeError("integer required");
             }
 
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.Multiply, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.Multiply, a, b);
         }
 
         public static object __repeat__(CodeContext/*!*/  context, object a, object b) {
@@ -441,7 +441,7 @@ namespace IronPython.Modules {
         }
 
         public static void setitem(CodeContext/*!*/ context, object a, object b, object c) {
-            PythonContext.GetContext(context).SetIndex(a, b, c);
+            context.LanguageContext.SetIndex(a, b, c);
         }
 
         public static void __setitem__(CodeContext/*!*/ context, object a, object b, object c) {
@@ -449,7 +449,7 @@ namespace IronPython.Modules {
         }
 
         public static void setslice(CodeContext/*!*/ context, object a, object b, object c, object v) {
-            PythonContext.GetContext(context).SetSlice(a, b, c, v);
+            context.LanguageContext.SetSlice(a, b, c, v);
         }
 
         public static void __setslice__(CodeContext/*!*/ context, object a, object b, object c, object v) {
@@ -502,61 +502,61 @@ namespace IronPython.Modules {
         }
         
         public static object iadd(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceAdd, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceAdd, a, b);
         }
 
         public static object iand(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceBitwiseAnd, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceBitwiseAnd, a, b);
         }
 
         public static object idiv(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceDivide, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceDivide, a, b);
         }
 
         public static object ifloordiv(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceFloorDivide, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceFloorDivide, a, b);
         }
 
         public static object ilshift(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceLeftShift, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceLeftShift, a, b);
         }
 
         public static object imod(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceMod, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceMod, a, b);
         }
 
         public static object imul(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceMultiply, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceMultiply, a, b);
         }
 
         public static object ior(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceBitwiseOr, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceBitwiseOr, a, b);
         }
 
         public static object ipow(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlacePower, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlacePower, a, b);
         }
 
         public static object irshift(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceRightShift, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceRightShift, a, b);
         }
 
         public static object isub(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceSubtract, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceSubtract, a, b);
         }
 
         public static object itruediv(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceTrueDivide, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceTrueDivide, a, b);
         }
 
         public static object ixor(CodeContext/*!*/ context, object a, object b) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceExclusiveOr, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceExclusiveOr, a, b);
         }
 
         public static object iconcat(CodeContext/*!*/ context, object a, object b) {
             TestBothSequence(a, b);
 
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceAdd, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceAdd, a, b);
         }
 
         public static object irepeat(CodeContext/*!*/ context, object a, object b) {
@@ -570,7 +570,7 @@ namespace IronPython.Modules {
                 throw PythonOps.TypeError("integer required");
             }
 
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.InPlaceMultiply, a, b);
+            return context.LanguageContext.Operation(PythonOperationKind.InPlaceMultiply, a, b);
         }
 
         public static object __iadd__(CodeContext/*!*/ context, object a, object b) {

--- a/Src/IronPython.Modules/re.cs
+++ b/Src/IronPython.Modules/re.cs
@@ -310,7 +310,7 @@ namespace IronPython.Modules {
             internal MatchCollection FindAllWorker(CodeContext/*!*/ context, string str, int pos, object endpos) {
                 string against = str;
                 if (endpos != null) {
-                    int end = PythonContext.GetContext(context).ConvertToInt32(endpos);
+                    int end = context.LanguageContext.ConvertToInt32(endpos);
                     against = against.Substring(0, Math.Max(end, 0));
                 }
                 return _re.Matches(against, pos);
@@ -319,7 +319,7 @@ namespace IronPython.Modules {
             internal MatchCollection FindAllWorker(CodeContext/*!*/ context, IList<byte> str, int pos, object endpos) {
                 string against = str.MakeString();
                 if (endpos != null) {
-                    int end = PythonContext.GetContext(context).ConvertToInt32(endpos);
+                    int end = context.LanguageContext.ConvertToInt32(endpos);
                     against = against.Substring(0, Math.Max(end, 0));
                 }
                 return _re.Matches(against, pos);
@@ -1278,7 +1278,7 @@ namespace IronPython.Modules {
         }
 
         private static PythonType error(CodeContext/*!*/ context) {
-            return (PythonType)PythonContext.GetContext(context).GetModuleState("reerror");
+            return (PythonType)context.LanguageContext.GetModuleState("reerror");
         }
 
         class PatternKey : IEquatable<PatternKey> {

--- a/Src/IronPython.Modules/select.cs
+++ b/Src/IronPython.Modules/select.cs
@@ -98,7 +98,7 @@ namespace IronPython.Modules {
         }
 
         private static Exception MakeException(CodeContext/*!*/ context, object value) {
-            return PythonExceptions.CreateThrowable((PythonType)PythonContext.GetContext(context).GetModuleState("selecterror"), value);
+            return PythonExceptions.CreateThrowable((PythonType)context.LanguageContext.GetModuleState("selecterror"), value);
         }
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace IronPython.Modules {
             socket = PythonSocket.socket.HandleToSocket(handle);
             if (socket == null) {
                 SocketException e = new SocketException((int)SocketError.NotSocket);
-                throw PythonExceptions.CreateThrowable((PythonType)PythonContext.GetContext(context).GetModuleState("selecterror"), SocketExceptionToTuple(e));
+                throw PythonExceptions.CreateThrowable((PythonType)context.LanguageContext.GetModuleState("selecterror"), SocketExceptionToTuple(e));
             }
             return socket;
         }

--- a/Src/IronPython.Modules/signal.cs
+++ b/Src/IronPython.Modules/signal.cs
@@ -199,11 +199,11 @@ The fd must be non-blocking.")]
         private static readonly object _PythonSignalStateKey = new object();
         
         private static PythonSignalState GetPythonSignalState(CodeContext/*!*/ context) {
-            return (PythonSignalState)PythonContext.GetContext(context).GetModuleState(_PythonSignalStateKey);
+            return (PythonSignalState)context.LanguageContext.GetModuleState(_PythonSignalStateKey);
         }
         
         private static void SetPythonSignalState(CodeContext/*!*/ context, PythonSignalState pss) {
-            PythonContext.GetContext(context).SetModuleState(_PythonSignalStateKey, pss);
+            context.LanguageContext.SetModuleState(_PythonSignalStateKey, pss);
         }
 
         internal class PythonSignalState {

--- a/Src/IronPython.Modules/socket.cs
+++ b/Src/IronPython.Modules/socket.cs
@@ -1320,7 +1320,7 @@ namespace IronPython.Modules {
         }
 
         private static PythonType gaierror(CodeContext/*!*/ context) {
-            return (PythonType)PythonContext.GetContext(context).GetModuleState("socketgaierror");
+            return (PythonType)context.LanguageContext.GetModuleState("socketgaierror");
         }
 
         private static IPHostEntry GetHostEntry(string host) {
@@ -2231,7 +2231,7 @@ namespace IronPython.Modules {
 
             int port;
             try {
-                port = PythonContext.GetContext(context).ConvertToInt32(address[1]);
+                port = context.LanguageContext.ConvertToInt32(address[1]);
             } catch (ArgumentTypeException) {
                 throw PythonOps.TypeError("port must be integer");
             }
@@ -2381,7 +2381,7 @@ namespace IronPython.Modules {
             public object bufsize = DefaultBufferSize; // Only present for compatibility with CPython public API
 
             public _fileobject(CodeContext/*!*/ context, object socket, [DefaultParameterValue("rb")]string mode, [DefaultParameterValue(-1)]int bufsize, [DefaultParameterValue(false)]bool close)
-                : base(PythonContext.GetContext(context)) {
+                : base(context.LanguageContext) {
 
                 Stream stream;
                 _close = close;
@@ -2443,35 +2443,35 @@ namespace IronPython.Modules {
 
             [SpecialName, PropertyMethod, StaticExtensionMethod]
             public static object Getdefault_bufsize(CodeContext/*!*/ context) {
-                return PythonContext.GetContext(context).GetModuleState(_defaultBufsizeKey);
+                return context.LanguageContext.GetModuleState(_defaultBufsizeKey);
             }
 
             [SpecialName, PropertyMethod, StaticExtensionMethod]
             public static void Setdefault_bufsize(CodeContext/*!*/ context, object value) {
-                PythonContext.GetContext(context).SetModuleState(_defaultBufsizeKey, value);
+                context.LanguageContext.SetModuleState(_defaultBufsizeKey, value);
             }
 
         }
         #endregion
 
         private static int? GetDefaultTimeout(CodeContext/*!*/ context) {
-            return (int?)PythonContext.GetContext(context).GetModuleState(_defaultTimeoutKey);
+            return (int?)context.LanguageContext.GetModuleState(_defaultTimeoutKey);
         }
 
         private static void SetDefaultTimeout(CodeContext/*!*/ context, int? timeout) {
-            PythonContext.GetContext(context).SetModuleState(_defaultTimeoutKey, timeout);
+            context.LanguageContext.SetModuleState(_defaultTimeoutKey, timeout);
         }
 
         private static PythonType error(CodeContext/*!*/ context) {
-            return (PythonType)PythonContext.GetContext(context).GetModuleState("socketerror");
+            return (PythonType)context.LanguageContext.GetModuleState("socketerror");
         }
 
         private static PythonType herror(CodeContext/*!*/ context) {
-            return (PythonType)PythonContext.GetContext(context).GetModuleState("socketherror");
+            return (PythonType)context.LanguageContext.GetModuleState("socketherror");
         }
 
         private static PythonType timeout(CodeContext/*!*/ context) {
-            return (PythonType)PythonContext.GetContext(context).GetModuleState("sockettimeout");
+            return (PythonType)context.LanguageContext.GetModuleState("sockettimeout");
         }
 
         public class ssl {

--- a/Src/IronPython.Modules/thread.cs
+++ b/Src/IronPython.Modules/thread.cs
@@ -177,7 +177,7 @@ namespace IronPython.Modules {
 
             public void release(CodeContext/*!*/ context) {
                 if (Interlocked.Exchange<Thread>(ref curHolder, null) == null) {
-                    throw PythonExceptions.CreateThrowable((PythonType)PythonContext.GetContext(context).GetModuleState("threaderror"), "lock isn't held", null);
+                    throw PythonExceptions.CreateThrowable((PythonType)context.LanguageContext.GetModuleState("threaderror"), "lock isn't held", null);
                 }
                 if (blockEvent != null) {
                     // if this isn't set yet we race, it's handled in Acquire()
@@ -238,9 +238,9 @@ namespace IronPython.Modules {
                 } catch (SystemExitException) {
                     // ignore and quit
                 } catch (Exception e) {
-                    PythonOps.PrintWithDest(_context, PythonContext.GetContext(_context).SystemStandardError, "Unhandled exception on thread");
+                    PythonOps.PrintWithDest(_context, _context.LanguageContext.SystemStandardError, "Unhandled exception on thread");
                     string result = _context.LanguageContext.FormatException(e);
-                    PythonOps.PrintWithDest(_context, PythonContext.GetContext(_context).SystemStandardError, result);
+                    PythonOps.PrintWithDest(_context, _context.LanguageContext.SystemStandardError, result);
                 } finally {
                     lock (_threadCountKey) {
                         int curCount = (int)_context.LanguageContext.GetModuleState(_threadCountKey);
@@ -253,11 +253,11 @@ namespace IronPython.Modules {
         #endregion
 
         private static int GetStackSize(CodeContext/*!*/ context) {
-            return (int)PythonContext.GetContext(context).GetModuleState(_stackSizeKey);
+            return (int)context.LanguageContext.GetModuleState(_stackSizeKey);
         }
 
         private static void SetStackSize(CodeContext/*!*/ context, int stackSize) {
-            PythonContext.GetContext(context).SetModuleState(_stackSizeKey, stackSize);
+            context.LanguageContext.SetModuleState(_stackSizeKey, stackSize);
         }
 
         [PythonType]

--- a/Src/IronPython.Modules/time.cs
+++ b/Src/IronPython.Modules/time.cs
@@ -613,7 +613,7 @@ namespace IronPython.Modules {
 
             int[] ints = new int[MaxIndex];
             for (int i = 0; i < MaxIndex; i++) {
-                ints[i] = PythonContext.GetContext(context).ConvertToInt32(t[i]);
+                ints[i] = context.LanguageContext.ConvertToInt32(t[i]);
             }
 
             int year = ints[YearIndex];

--- a/Src/IronPython.Modules/zipimport.cs
+++ b/Src/IronPython.Modules/zipimport.cs
@@ -209,7 +209,7 @@ module, or raises ZipImportError if it wasn't found.")]
                 bool ispackage;
                 string modpath;
                 PythonModule mod;
-                PythonContext pythonContext = PythonContext.GetContext(context);
+                PythonContext pythonContext = context.LanguageContext;
                 PythonDictionary dict;
                 ScriptCode script = null;
                 byte[] code = GetModuleCode(context, fullname, out ispackage, out modpath);
@@ -307,7 +307,7 @@ contain the module, but has no source for it.")]
             public string get_source(CodeContext/*!*/ context, string fullname) {
                 ModuleStatus mi = GetModuleInfo(context, fullname);
                 string res = null;
-                PythonContext pythonContext = PythonContext.GetContext(context);
+                PythonContext pythonContext = context.LanguageContext;
                 if (mi == ModuleStatus.Error) {
                     return null;
                 }

--- a/Src/IronPython.Modules/zipimport.cs
+++ b/Src/IronPython.Modules/zipimport.cs
@@ -218,7 +218,7 @@ module, or raises ZipImportError if it wasn't found.")]
                 }
 
                 mod = pythonContext.CompileModule(modpath, fullname,
-                    new SourceUnit(pythonContext, new MemoryStreamContentProvider(context.GetPythonContext(), code, modpath), modpath, SourceCodeKind.File),
+                    new SourceUnit(pythonContext, new MemoryStreamContentProvider(pythonContext, code, modpath), modpath, SourceCodeKind.File),
                     ModuleOptions.None, out script);
 
                 dict = mod.__dict__;

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -91,7 +91,7 @@ namespace IronPython.Modules {
             }
 
             IList from = fromlist as IList;
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             object ret = Importer.ImportModule(context, globals, name, from != null && from.Count > 0, level);
             if (ret == null) {
@@ -440,7 +440,7 @@ namespace IronPython.Modules {
         public static object divmod(CodeContext/*!*/ context, object x, object y) {
             Debug.Assert(NotImplementedType.Value != null);
 
-            return PythonContext.GetContext(context).DivMod(x, y);
+            return context.LanguageContext.DivMod(x, y);
         }
 
         public static PythonType enumerate {
@@ -489,7 +489,7 @@ namespace IronPython.Modules {
 
             expression = RemoveBom(expression);
             var scope = GetExecEvalScopeOptional(context, globals, locals, false);
-            var pythonContext = PythonContext.GetContext(context);
+            var pythonContext = context.LanguageContext;
 
             // TODO: remove TrimStart
             var sourceUnit = pythonContext.CreateSnippet(expression.TrimStart(' ', '\t'), SourceCodeKind.Expression);
@@ -533,7 +533,7 @@ namespace IronPython.Modules {
 
             var execScope = GetExecEvalScopeOptional(context, g, l, true);
             string path = Converter.ConvertToString(filename);
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             if (!pc.DomainManager.Platform.FileExists(path)) {
                 throw PythonOps.IOError("execfile: specified file doesn't exist");
             }
@@ -675,7 +675,7 @@ namespace IronPython.Modules {
         }
 
         public static int hash(CodeContext/*!*/ context, [NotNull]PythonTuple o) {
-            return ((IStructuralEquatable)o).GetHashCode(PythonContext.GetContext(context).EqualityComparerNonGeneric);
+            return ((IStructuralEquatable)o).GetHashCode(context.LanguageContext.EqualityComparerNonGeneric);
         }
 
         // this is necessary because overload resolution selects the int form.
@@ -753,7 +753,7 @@ namespace IronPython.Modules {
 
                 // try and find things that string could refer to,
                 // then call help on them.
-                foreach (object module in PythonContext.GetContext(context).SystemStateModules.Values) {
+                foreach (object module in context.LanguageContext.SystemStateModules.Values) {
                     IList<object> attrs = PythonOps.GetAttrNames(context, module);
                     List candidates = new List();
                     foreach (string s in attrs) {
@@ -979,7 +979,7 @@ namespace IronPython.Modules {
                 // Recursively inspect nested tuple(s)
                 foreach (object subTypeInfo in pt) {
                     try {
-                        PythonOps.FunctionPushFrame(PythonContext.GetContext(context));
+                        PythonOps.FunctionPushFrame(context.LanguageContext);
                         var res = issubclass(context, o, subTypeInfo);
                         if (res == ScriptingRuntimeHelpers.True) {
                             return ScriptingRuntimeHelpers.True;
@@ -1114,7 +1114,7 @@ namespace IronPython.Modules {
 
         private static CallSite<Func<CallSite, CodeContext, T, T1, object>> MakeMapSite<T, T1>(CodeContext/*!*/ context) {
             return CallSite<Func<CallSite, CodeContext, T, T1, object>>.Create(
-                PythonContext.GetContext(context).InvokeOne
+                context.LanguageContext.InvokeOne
             );
         }
 
@@ -1302,7 +1302,7 @@ namespace IronPython.Modules {
             if (!i.MoveNext())
                 throw PythonOps.ValueError("max() arg is an empty sequence");
             object ret = i.Current;
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             while (i.MoveNext()) {
                 if (pc.GreaterThan(i.Current, ret)) ret = i.Current;
             }
@@ -1310,7 +1310,7 @@ namespace IronPython.Modules {
         }
 
         public static object max(CodeContext/*!*/ context, object x, object y) {
-            return PythonContext.GetContext(context).GreaterThan(x, y) ? x : y;
+            return context.LanguageContext.GreaterThan(x, y) ? x : y;
         }
 
         public static object max(CodeContext/*!*/ context, params object[] args) {
@@ -1320,7 +1320,7 @@ namespace IronPython.Modules {
                     return max(context, ret);
                 }
 
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
                 for (int i = 1; i < args.Length; i++) {
                     if (pc.GreaterThan(args[i], ret)) {
                         ret = args[i];
@@ -1340,7 +1340,7 @@ namespace IronPython.Modules {
             object method = GetMaxKwArg(dict);
             object ret = i.Current;
             object retValue = PythonCalls.Call(context, method, i.Current);
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             while (i.MoveNext()) {
                 object tmpRetValue = PythonCalls.Call(context, method, i.Current);
                 if (pc.GreaterThan(tmpRetValue, retValue)) {
@@ -1353,7 +1353,7 @@ namespace IronPython.Modules {
 
         public static object max(CodeContext/*!*/ context, object x, object y, [ParamDictionary] IDictionary<object, object> dict) {
             object method = GetMaxKwArg(dict);
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             return pc.GreaterThan(PythonCalls.Call(context, method, x), PythonCalls.Call(context, method, y)) ? x : y;
         }
 
@@ -1365,7 +1365,7 @@ namespace IronPython.Modules {
                 }
                 object method = GetMaxKwArg(dict);
                 object retValue = PythonCalls.Call(context, method, args[retIndex]);
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
                 for (int i = 1; i < args.Length; i++) {
                     object tmpRetValue = PythonCalls.Call(context, method, args[i]);
                     if (pc.GreaterThan(tmpRetValue, retValue)) {
@@ -1392,7 +1392,7 @@ namespace IronPython.Modules {
                 throw PythonOps.ValueError("empty sequence");
             }
             object ret = i.Current;
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             while (i.MoveNext()) {
                 if (pc.LessThan(i.Current, ret)) ret = i.Current;
             }
@@ -1400,7 +1400,7 @@ namespace IronPython.Modules {
         }
 
         public static object min(CodeContext/*!*/ context, object x, object y) {
-            return PythonContext.GetContext(context).LessThan(x, y) ? x : y;
+            return context.LanguageContext.LessThan(x, y) ? x : y;
         }
 
         public static object min(CodeContext/*!*/ context, params object[] args) {
@@ -1410,7 +1410,7 @@ namespace IronPython.Modules {
                     return min(context, ret);
                 }
 
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
                 for (int i = 1; i < args.Length; i++) {
                     if (pc.LessThan(args[i], ret)) ret = args[i];
                 }
@@ -1427,7 +1427,7 @@ namespace IronPython.Modules {
             object method = GetMinKwArg(dict);
             object ret = i.Current;
             object retValue = PythonCalls.Call(context, method, i.Current);
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             while (i.MoveNext()) {
                 object tmpRetValue = PythonCalls.Call(context, method, i.Current);
 
@@ -1441,7 +1441,7 @@ namespace IronPython.Modules {
 
         public static object min(CodeContext/*!*/ context, object x, object y, [ParamDictionary]IDictionary<object, object> dict) {
             object method = GetMinKwArg(dict);
-            return PythonContext.GetContext(context).LessThan(PythonCalls.Call(context, method, x), PythonCalls.Call(context, method, y)) ? x : y;
+            return context.LanguageContext.LessThan(PythonCalls.Call(context, method, x), PythonCalls.Call(context, method, y)) ? x : y;
         }
 
         public static object min(CodeContext/*!*/ context, [ParamDictionary]IDictionary<object, object> dict, params object[] args) {
@@ -1452,7 +1452,7 @@ namespace IronPython.Modules {
                 }
                 object method = GetMinKwArg(dict);
                 object retValue = PythonCalls.Call(context, method, args[retIndex]);
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
 
                 for (int i = 1; i < args.Length; i++) {
                     object tmpRetValue = PythonCalls.Call(context, method, args[i]);
@@ -1605,7 +1605,7 @@ namespace IronPython.Modules {
         }
 
         public static object pow(CodeContext/*!*/ context, object x, object y) {
-            return PythonContext.GetContext(context).Operation(PythonOperationKind.Power, x, y);
+            return context.LanguageContext.Operation(PythonOperationKind.Power, x, y);
         }
 
         public static object pow(CodeContext/*!*/ context, object x, object y, object z) {
@@ -1654,7 +1654,7 @@ namespace IronPython.Modules {
         }
 
         private static void print(CodeContext/*!*/ context, string/*!*/ sep, string/*!*/ end, object file, object[]/*!*/ args) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             if (file == null) {
                 file = pc.SystemStandardOut;
@@ -1936,7 +1936,7 @@ namespace IronPython.Modules {
         }
 
         public static string raw_input(CodeContext/*!*/ context, object prompt) {
-            var pc = PythonContext.GetContext(context);
+            var pc = context.LanguageContext;
             var readlineModule = pc.GetModuleByName("readline");
             string line;
             if (readlineModule != null) {
@@ -1946,7 +1946,7 @@ namespace IronPython.Modules {
                 if (prompt != null) {
                     PythonOps.PrintNoNewline(context, prompt);
                 }
-                line = PythonOps.ReadLineFromSrc(context, PythonContext.GetContext(context).SystemStandardIn) as string;
+                line = PythonOps.ReadLineFromSrc(context, context.LanguageContext.SystemStandardIn) as string;
             }
 
             if (line != null && line.EndsWith("\n")) return line.Substring(0, line.Length - 1);
@@ -1987,7 +1987,7 @@ namespace IronPython.Modules {
         private static void EnsureReduceData(CodeContext context, SiteLocalStorage<CallSite<Func<CallSite, CodeContext, object, object, object, object>>> siteData) {
             if (siteData.Data == null) {
                 siteData.Data = CallSite<Func<CallSite, CodeContext, object, object, object, object>>.Create(
-                    PythonContext.GetContext(context).Invoke(
+                    context.LanguageContext.Invoke(
                         new CallSignature(2)
                     )
                 );
@@ -2460,7 +2460,7 @@ namespace IronPython.Modules {
             PythonDictionary locals, bool copyModule, bool setBuiltinsToModule) {
 
             Assert.NotNull(context, globals);
-            PythonContext python = PythonContext.GetContext(context);
+            PythonContext python = context.LanguageContext;
 
             // TODO: Need to worry about propagating changes to MC out?
             var mc = new ModuleContext(PythonDictionary.FromIAC(context, globals), context.LanguageContext);

--- a/Src/IronPython/Modules/imp.cs
+++ b/Src/IronPython/Modules/imp.cs
@@ -82,7 +82,7 @@ namespace IronPython.Modules {
                 throw PythonOps.TypeError("load_module() argument 4 must be sequence of length 3, not {0}", description.__len__());
             }
 
-            PythonContext pythonContext = PythonContext.GetContext(context);
+            PythonContext pythonContext = context.LanguageContext;
 
             // already loaded? do reload()
             PythonModule module = pythonContext.GetModuleByName(name);
@@ -91,7 +91,7 @@ namespace IronPython.Modules {
                 return module;
             }
 
-            int type = PythonContext.GetContext(context).ConvertToInt32(description[2]);
+            int type = context.LanguageContext.ConvertToInt32(description[2]);
             switch (type) {
                 case PythonSource:
                     return LoadPythonSource(pythonContext, name, file, filename);
@@ -163,7 +163,7 @@ namespace IronPython.Modules {
         public static int is_builtin(CodeContext/*!*/ context, string/*!*/ name) {
             if (name == null) throw PythonOps.TypeError("is_builtin() argument 1 must be string, not None");
             Type ty;
-            if (PythonContext.GetContext(context).BuiltinModules.TryGetValue(name, out ty)) {
+            if (context.LanguageContext.BuiltinModules.TryGetValue(name, out ty)) {
                 if (ty.GetTypeInfo().Assembly == typeof(PythonContext).GetTypeInfo().Assembly) {
                     // supposedly these can't be re-initialized and return -1 to
                     // indicate that here, but CPython does allow passing them
@@ -206,7 +206,7 @@ namespace IronPython.Modules {
         }
 
         private static PythonModule/*!*/ CreateEmptyPackage(CodeContext/*!*/ context, string/*!*/ name, string/*!*/ pathname) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             PythonModule mod = new PythonModule();
             mod.__dict__["__name__"] = name;
@@ -223,7 +223,7 @@ namespace IronPython.Modules {
             
             // TODO: is this supposed to open PythonFile with Python-specific behavior?
             // we may need to insert additional layer to SourceUnit content provider if so
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             if (!pc.DomainManager.Platform.FileExists(pathname)) {
                 throw PythonOps.IOError("Couldn't find file: {0}", pathname);
             }
@@ -237,7 +237,7 @@ namespace IronPython.Modules {
             if (pathname == null) throw PythonOps.TypeError("load_source() argument 2 must be string, not None");
             if (file == null) throw PythonOps.TypeError("load_source() argument 3 must be file, not None");
             
-            return LoadPythonSource(PythonContext.GetContext(context), name, file, pathname);
+            return LoadPythonSource(context.LanguageContext, name, file, pathname);
         }
 
         public static object reload(CodeContext/*!*/ context, PythonModule scope) {
@@ -248,7 +248,7 @@ namespace IronPython.Modules {
 
         private static PythonTuple FindBuiltinOrSysPath(CodeContext/*!*/ context, string/*!*/ name) {
             List sysPath;
-            if (!PythonContext.GetContext(context).TryGetSystemPath(out sysPath)) {
+            if (!context.LanguageContext.TryGetSystemPath(out sysPath)) {
                 throw PythonOps.ImportError("sys.path must be a list of directory names");
             }
             return FindModuleBuiltinOrPath(context, name, sysPath);
@@ -290,7 +290,7 @@ namespace IronPython.Modules {
                 return BuiltinModuleTuple(name);
             }
             Type ty;
-            if (PythonContext.GetContext(context).BuiltinModules.TryGetValue(name, out ty)) {
+            if (context.LanguageContext.BuiltinModules.TryGetValue(name, out ty)) {
                 return BuiltinModuleTuple(name);
             }
 
@@ -321,11 +321,11 @@ namespace IronPython.Modules {
         #endregion
 
         private static long GetLockCount(CodeContext/*!*/ context) {
-            return (long)PythonContext.GetContext(context).GetModuleState(_lockCountKey);
+            return (long)context.LanguageContext.GetModuleState(_lockCountKey);
         }
 
         private static void SetLockCount(CodeContext/*!*/ context, long lockCount) {
-            PythonContext.GetContext(context).SetModuleState(_lockCountKey, lockCount);
+            context.LanguageContext.SetModuleState(_lockCountKey, lockCount);
         }
 
         [PythonType]

--- a/Src/IronPython/Modules/sys.cs
+++ b/Src/IronPython/Modules/sys.cs
@@ -87,7 +87,7 @@ Print an object to sys.stdout and also save it in __builtin__._")]
         public static void displayhookImpl(CodeContext/*!*/ context, object value) {
             if (value != null) {
                 PythonOps.Print(context, PythonOps.Repr(context, value));
-                PythonContext.GetContext(context).BuiltinModuleDict["_"] = value;
+                context.LanguageContext.BuiltinModuleDict["_"] = value;
             }
         }
 
@@ -106,7 +106,7 @@ Print an object to sys.stdout and also save it in __builtin__._")]
 
 Handle an exception by displaying it with a traceback on sys.stderr._")]
         public static void excepthookImpl(CodeContext/*!*/ context, object exctype, object value, object traceback) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             PythonOps.PrintWithDest(
                 context,
@@ -172,7 +172,7 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
         }
 
         public static string getdefaultencoding(CodeContext/*!*/ context) {
-            return PythonContext.GetContext(context).GetDefaultEncodingName();
+            return context.LanguageContext.GetDefaultEncodingName();
         }
 
         public static object getfilesystemencoding() {
@@ -291,7 +291,7 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
             string strName = name as string;
             if (strName == null) throw PythonOps.TypeError("name must be a string");
 
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             Encoding enc;
             if (!StringOps.TryGetEncoding(strName, out enc)) {
                 throw PythonOps.LookupError("'{0}' does not match any available encodings", strName);
@@ -305,7 +305,7 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
         // difficult because it's hard to flip tracing on/off for them w/o a perf overhead in the 
         // non-profiling case.
         public static void setprofile(CodeContext/*!*/ context, TracebackDelegate o) {
-            PythonContext pyContext = PythonContext.GetContext(context);
+            PythonContext pyContext = context.LanguageContext;
             pyContext.EnsureDebugContext();
 
             if (o == null) {
@@ -332,11 +332,11 @@ Handle an exception by displaying it with a traceback on sys.stderr._")]
         }
 
         public static void setrecursionlimit(CodeContext/*!*/ context, int limit) {
-            PythonContext.GetContext(context).RecursionLimit = limit;
+            context.LanguageContext.RecursionLimit = limit;
         }
 
         public static int getrecursionlimit(CodeContext/*!*/ context) {
-            return PythonContext.GetContext(context).RecursionLimit;
+            return context.LanguageContext.RecursionLimit;
         }
 
         // stdin, stdout, stderr, __stdin__, __stdout__, and __stderr__ added by PythonContext

--- a/Src/IronPython/Runtime/Binding/MetaPythonType.Members.cs
+++ b/Src/IronPython/Runtime/Binding/MetaPythonType.Members.cs
@@ -204,7 +204,7 @@ namespace IronPython.Runtime.Binding {
                 PythonTypeSlot pts;
 
                 bool isFinal = false, metaOnly = false;
-                CodeContext lookupContext = PythonContext.GetContext(_context).SharedClsContext;
+                CodeContext lookupContext = _context.LanguageContext.SharedClsContext;
 
                 // first look in the meta-class to see if we have a get/set descriptor
                 PythonType metaType = DynamicHelpers.GetPythonType(Value);
@@ -689,7 +689,7 @@ namespace IronPython.Runtime.Binding {
                         _weakMetaType = metaType.GetSharedWeakReference();
                         _weakSlot = new WeakReference(slot);
                     }
-                    _invokeSite = CallSite<Func<CallSite, CodeContext, object, string, object>>.Create(PythonContext.GetContext(context).InvokeOne);
+                    _invokeSite = CallSite<Func<CallSite, CodeContext, object, string, object>>.Create(context.LanguageContext.InvokeOne);
                 }
 
                 public bool Target(CodeContext context, object self, out object result) {

--- a/Src/IronPython/Runtime/Binding/PythonBinder.cs
+++ b/Src/IronPython/Runtime/Binding/PythonBinder.cs
@@ -503,7 +503,7 @@ namespace IronPython.Runtime.Binding {
         /// Gets the PythonBinder associated with tihs CodeContext
         /// </summary>
         public static PythonBinder/*!*/ GetBinder(CodeContext/*!*/ context) {
-            return (PythonBinder)PythonContext.GetContext(context).Binder;
+            return (PythonBinder)context.LanguageContext.Binder;
         }
 
         /// <summary>

--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -862,7 +862,7 @@ namespace IronPython.Runtime {
             }
 
             throw PythonOps.TypeError("Type {0} doesn't support the buffer API",
-                PythonContext.GetContext(context).PythonOptions.Python30 ? PythonTypeOps.GetOldName(value) : PythonTypeOps.GetName(value));
+                context.LanguageContext.PythonOptions.Python30 ? PythonTypeOps.GetOldName(value) : PythonTypeOps.GetName(value));
         }
 
         public PythonTuple __reduce__(CodeContext/*!*/ context) {

--- a/Src/IronPython/Runtime/Bytes.cs
+++ b/Src/IronPython/Runtime/Bytes.cs
@@ -637,7 +637,7 @@ namespace IronPython.Runtime {
         }
 
         public bool __contains__(CodeContext/*!*/ context, int value) {
-            if (!PythonContext.GetContext(context).PythonOptions.Python30) {
+            if (!context.LanguageContext.PythonOptions.Python30) {
                 throw PythonOps.TypeError("'in <bytes>' requires string or bytes as left operand, not int");
             }
 
@@ -648,7 +648,7 @@ namespace IronPython.Runtime {
             if (value is Extensible<string>) {
                 return __contains__(PythonOps.MakeBytes(((Extensible<string>)value).Value.MakeByteArray()));
             }
-            if (!PythonContext.GetContext(context).PythonOptions.Python30) {
+            if (!context.LanguageContext.PythonOptions.Python30) {
                 throw PythonOps.TypeError("'in <bytes>' requires string or bytes as left operand, not {0}", PythonTypeOps.GetName(value));
             }
 
@@ -759,7 +759,7 @@ namespace IronPython.Runtime {
         public object this[CodeContext/*!*/ context, int index] {
             get {
                 byte res = _bytes[PythonOps.FixIndex(index, _bytes.Length)];
-                if (PythonContext.GetContext(context).PythonOptions.Python30) {
+                if (context.LanguageContext.PythonOptions.Python30) {
                     return (int)res;
                 }
 

--- a/Src/IronPython/Runtime/ClrModule.cs
+++ b/Src/IronPython/Runtime/ClrModule.cs
@@ -209,7 +209,7 @@ the assembly object.")]
                 throw new TypeErrorException("LoadAssemblyByName: arg 1 must be a string");
             }
 
-            return PythonContext.GetContext(context).DomainManager.Platform.LoadAssembly(name);
+            return context.LanguageContext.DomainManager.Platform.LoadAssembly(name);
         }
 
         /// <summary>
@@ -224,7 +224,7 @@ the assembly object.")]
                 throw new TypeErrorException("Use: arg 1 must be a string");
             }
 
-            var scope = Importer.TryImportSourceFile(PythonContext.GetContext(context), name);
+            var scope = Importer.TryImportSourceFile(context.LanguageContext, name);
             if (scope == null) {
                 throw new ValueErrorException(String.Format("couldn't find module {0} to use", name));
             }
@@ -520,7 +520,7 @@ import Namespace.")]
             string path = System.IO.Path.GetDirectoryName(Path.GetFullPath(file));
             List list;
 
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             if (!pc.TryGetSystemPath(out list)) {
                 throw PythonOps.TypeError("cannot update path, it is not a list");
             }
@@ -845,7 +845,7 @@ import Namespace.")]
             ContractUtils.RequiresNotNull(assemblyName, "assemblyName");
             ContractUtils.RequiresNotNullItems(filenames, "filenames");
 
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             for (int i = 0; i < filenames.Length; i++) {
                 filenames[i] = Path.GetFullPath(filenames[i]);
@@ -896,7 +896,7 @@ import Namespace.")]
                     SourceCodeKind.File
                 );
 
-                sc = PythonContext.GetContext(context).GetScriptCode(su, modName, ModuleOptions.Initialize, Compiler.CompilationMode.ToDisk);
+                sc = context.LanguageContext.GetScriptCode(su, modName, ModuleOptions.Initialize, Compiler.CompilationMode.ToDisk);
 
                 code.Add((SavableScriptCode)sc);
             }
@@ -910,7 +910,7 @@ import Namespace.")]
                     }
                     
                     SourceUnit su = pc.CreateFileUnit(strModule, pc.DefaultEncoding, SourceCodeKind.File);
-                    code.Add((SavableScriptCode)PythonContext.GetContext(context).GetScriptCode(su, "__main__", ModuleOptions.Initialize, Compiler.CompilationMode.ToDisk));
+                    code.Add((SavableScriptCode)context.LanguageContext.GetScriptCode(su, "__main__", ModuleOptions.Initialize, Compiler.CompilationMode.ToDisk));
                 }
             }
 
@@ -1105,14 +1105,14 @@ import Namespace.")]
         /// All times are expressed in the same unit of measure as DateTime.Ticks
         /// </summary>
         public static PythonTuple GetProfilerData(CodeContext/*!*/ context, [DefaultParameterValue(false)]bool includeUnused) {
-            return new PythonTuple(Profiler.GetProfiler(PythonContext.GetContext(context)).GetProfile(includeUnused));
+            return new PythonTuple(Profiler.GetProfiler(context.LanguageContext).GetProfile(includeUnused));
         }
 
         /// <summary>
         /// Resets all profiler counters back to zero
         /// </summary>
         public static void ClearProfilerData(CodeContext/*!*/ context) {
-            Profiler.GetProfiler(PythonContext.GetContext(context)).Reset();
+            Profiler.GetProfiler(context.LanguageContext).Reset();
         }
 
         /// <summary>
@@ -1123,7 +1123,7 @@ import Namespace.")]
         /// The easiest way to recompile a module is to reload() it.
         /// </summary>
         public static void EnableProfiler(CodeContext/*!*/ context, bool enable) {
-            var pc = PythonContext.GetContext(context);
+            var pc = context.LanguageContext;
             var po = pc.Options as PythonOptions;
             po.EnableProfiler = enable;
         }

--- a/Src/IronPython/Runtime/Descriptors.cs
+++ b/Src/IronPython/Runtime/Descriptors.cs
@@ -204,7 +204,7 @@ namespace IronPython.Runtime {
             if (instance == null) {
                 return this;
             } else if (fget != null) {
-                var site = PythonContext.GetContext(context).PropertyGetSite;
+                var site = context.LanguageContext.PropertyGetSite;
 
                 return site.Target(site, context, fget, instance);
             }
@@ -213,7 +213,7 @@ namespace IronPython.Runtime {
 
         public override void __set__(CodeContext/*!*/ context, object instance, object value) {
             if (fset != null) {
-                var site = PythonContext.GetContext(context).PropertySetSite;
+                var site = context.LanguageContext.PropertySetSite;
 
                 site.Target(site, context, fset, instance, value);
             } else {
@@ -223,7 +223,7 @@ namespace IronPython.Runtime {
 
         public override void __delete__(CodeContext/*!*/ context, object instance) {
             if (fdel != null) {
-                var site = PythonContext.GetContext(context).PropertyDeleteSite;
+                var site = context.LanguageContext.PropertyDeleteSite;
 
                 site.Target(site, context, fdel, instance);
             } else {

--- a/Src/IronPython/Runtime/Exceptions/TraceBack.cs
+++ b/Src/IronPython/Runtime/Exceptions/TraceBack.cs
@@ -198,7 +198,7 @@ namespace IronPython.Runtime.Exceptions {
 
         public object f_builtins {
             get {
-                return PythonContext.GetContext(_context).BuiltinModuleDict;
+                return _context.LanguageContext.BuiltinModuleDict;
             }
         }
 

--- a/Src/IronPython/Runtime/FunctionCode.cs
+++ b/Src/IronPython/Runtime/FunctionCode.cs
@@ -626,7 +626,7 @@ namespace IronPython.Runtime {
             }
 
             var func = new PythonFunction(context, this, null, ArrayUtils.EmptyObjects, new MutableTuple<object>());
-            CallSite<Func<CallSite, CodeContext, PythonFunction, object>> site = PythonContext.GetContext(context).FunctionCallSite;
+            CallSite<Func<CallSite, CodeContext, PythonFunction, object>> site = context.LanguageContext.FunctionCallSite;
             return site.Target(site, context, func);
         }
 
@@ -720,7 +720,7 @@ namespace IronPython.Runtime {
         /// </summary>
         internal void LazyCompileFirstTarget(PythonFunction function) {
             lock (_CodeCreateAndUpdateDelegateLock) {
-                UpdateDelegate(PythonContext.GetContext(function.Context), true);
+                UpdateDelegate(function.Context.LanguageContext, true);
             }
         }
 

--- a/Src/IronPython/Runtime/Generator.cs
+++ b/Src/IronPython/Runtime/Generator.cs
@@ -333,8 +333,8 @@ namespace IronPython.Runtime {
 
                 string message = "Exception in generator " + __repr__(Context) + " ignored";
 
-                PythonOps.PrintWithDest(Context, PythonContext.GetContext(Context).SystemStandardError, message);
-                PythonOps.PrintWithDest(Context, PythonContext.GetContext(Context).SystemStandardError, Context.LanguageContext.FormatException(e));
+                PythonOps.PrintWithDest(Context, Context.LanguageContext.SystemStandardError, message);
+                PythonOps.PrintWithDest(Context, Context.LanguageContext.SystemStandardError, Context.LanguageContext.FormatException(e));
             } catch {
                 // if stderr is closed then ignore any exceptions.
             }

--- a/Src/IronPython/Runtime/Importer.cs
+++ b/Src/IronPython/Runtime/Importer.cs
@@ -56,7 +56,7 @@ namespace IronPython.Runtime {
         /// </summary>
         [LightThrowing]
         internal static object ImportLightThrow(CodeContext/*!*/ context, string fullName, PythonTuple from, int level) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             if (level == -1) {
                 // no specific level provided, call the 4 param version so legacy code continues to work
@@ -266,7 +266,7 @@ namespace IronPython.Runtime {
                 // try an absolute import
                 if (newmod == null) {
                     object parentPkg;
-                    if (!String.IsNullOrEmpty(package) && !PythonContext.GetContext(context).SystemStateModules.TryGetValue(package, out parentPkg)) {
+                    if (!String.IsNullOrEmpty(package) && !context.LanguageContext.SystemStateModules.TryGetValue(package, out parentPkg)) {
                         PythonModule warnModule = new PythonModule();
                         warnModule.__dict__["__file__"] = package;
                         warnModule.__dict__["__name__"] = package;
@@ -367,7 +367,7 @@ namespace IronPython.Runtime {
                         // absolute import of some module
                         full = modName + "." + name;
                         object parentModule;
-                        if (PythonContext.GetContext(context).SystemStateModules.TryGetValue(modName, out parentModule)) {
+                        if (context.LanguageContext.SystemStateModules.TryGetValue(modName, out parentModule)) {
                             parentMod = parentModule as PythonModule;
                         }
                     } else if (String.IsNullOrEmpty(name)) {
@@ -378,7 +378,7 @@ namespace IronPython.Runtime {
                         string parentName = (StringOps.rsplit(modName, ".", level - 1)[0] as string);
                         full = parentName + "." + name;
                         object parentModule;
-                        if (PythonContext.GetContext(context).SystemStateModules.TryGetValue(parentName, out parentModule)) {
+                        if (context.LanguageContext.SystemStateModules.TryGetValue(parentName, out parentModule)) {
                             parentMod = parentModule as PythonModule;
                         }
                     }
@@ -447,7 +447,7 @@ namespace IronPython.Runtime {
         }
 
         internal static object ReloadModule(CodeContext/*!*/ context, PythonModule/*!*/ module, PythonFile file) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             // We created the module and it only contains Python code. If the user changes
             // __file__ we'll reload from that file. 
@@ -475,7 +475,7 @@ namespace IronPython.Runtime {
                 }
 
                 List sysPath;
-                if (PythonContext.GetContext(context).TryGetSystemPath(out sysPath)) {
+                if (context.LanguageContext.TryGetSystemPath(out sysPath)) {
                     object ret = ImportFromPathHook(context, name, name, sysPath, null);
                     if (ret != null) {
                         return ret;
@@ -517,7 +517,7 @@ namespace IronPython.Runtime {
             parentModule = null;
 
             // Try lookup parent module in the sys.modules
-            if (PythonContext.GetContext(context).SystemStateModules.TryGetValue(parentModuleName, out parentModuleObj)) {
+            if (context.LanguageContext.SystemStateModules.TryGetValue(parentModuleName, out parentModuleObj)) {
                 // see if it's a module
                 parentModule = parentModuleObj as PythonModule;
                 if (parentModule != null) {
@@ -537,7 +537,7 @@ namespace IronPython.Runtime {
             Type type;
 
             string name = (string)module.GetName();
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             if (!pc.BuiltinModules.TryGetValue(name, out type)) {
                 throw PythonOps.ImportError("no module named {0}", module.GetName());
@@ -567,7 +567,7 @@ namespace IronPython.Runtime {
         /// searching sys.path but after searching built-in modules.
         /// </summary>
         private static bool TryLoadMetaPathModule(CodeContext/*!*/ context, string fullName, List path, out object ret) {
-            List metaPath = PythonContext.GetContext(context).GetSystemStateValue("meta_path") as List;
+            List metaPath = context.LanguageContext.GetSystemStateValue("meta_path") as List;
             if (metaPath != null) {
                 foreach (object importer in (IEnumerable)metaPath) {
                     if (FindAndLoadModuleFromImporter(context, importer, fullName, path, out ret)) {
@@ -588,7 +588,7 @@ namespace IronPython.Runtime {
         private static bool FindAndLoadModuleFromImporter(CodeContext/*!*/ context, object importer, string fullName, List path, out object ret) {
             object find_module = PythonOps.GetBoundAttr(context, importer, "find_module");
 
-            PythonContext pycontext = PythonContext.GetContext(context);
+            PythonContext pycontext = context.LanguageContext;
             object loader = pycontext.Call(context, find_module, fullName, path);
             if (loader != null) {
                 object findMod = PythonOps.GetBoundAttr(context, loader, "load_module");
@@ -601,7 +601,7 @@ namespace IronPython.Runtime {
         }
 
         internal static bool TryGetExistingModule(CodeContext/*!*/ context, string/*!*/ fullName, out object ret) {
-            if (PythonContext.GetContext(context).SystemStateModules.TryGetValue(fullName, out ret)) {
+            if (context.LanguageContext.SystemStateModules.TryGetValue(fullName, out ret)) {
                 return true;
             }
             return false;
@@ -621,7 +621,7 @@ namespace IronPython.Runtime {
                 }
 
                 NamespaceTracker rp = ret as NamespaceTracker;
-                if (rp != null || ret == PythonContext.GetContext(context).ClrModule) {
+                if (rp != null || ret == context.LanguageContext.ClrModule) {
                     context.ShowCls = true;
                 }
 
@@ -636,7 +636,7 @@ namespace IronPython.Runtime {
             if (ret != null) return ret;
 
             List path;
-            if (PythonContext.GetContext(context).TryGetSystemPath(out path)) {
+            if (context.LanguageContext.TryGetSystemPath(out path)) {
                 ret = ImportFromPath(context, name, name, path);
                 if (ret != null) return ret;
             }
@@ -693,7 +693,7 @@ namespace IronPython.Runtime {
 
             ImportFromPath(context, name, fullName, path);
             object importedModule;
-            if (PythonContext.GetContext(context).SystemStateModules.TryGetValue(fullName, out importedModule)) {
+            if (context.LanguageContext.SystemStateModules.TryGetValue(fullName, out importedModule)) {
                 module.__dict__[name] = importedModule;
                 return importedModule;
             }
@@ -702,7 +702,7 @@ namespace IronPython.Runtime {
         }
 
         private static object FindImportFunction(CodeContext/*!*/ context) {
-            PythonDictionary builtins = context.GetBuiltinsDict() ?? PythonContext.GetContext(context).BuiltinModuleDict;
+            PythonDictionary builtins = context.GetBuiltinsDict() ?? context.LanguageContext.BuiltinModuleDict;
 
             object import;
             if (builtins._storage.TryGetImport(out import)) {
@@ -715,7 +715,7 @@ namespace IronPython.Runtime {
         internal static object ImportBuiltin(CodeContext/*!*/ context, string/*!*/ name) {
             Assert.NotNull(context, name);
 
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             if (name == "sys") {
                 return pc.SystemState;
             } else if (name == "clr") {
@@ -729,7 +729,7 @@ namespace IronPython.Runtime {
 
         private static object ImportReflected(CodeContext/*!*/ context, string/*!*/ name) {
             object ret;
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             if (!PythonOps.ScopeTryGetMember(context, pc.DomainManager.Globals, name, out ret) &&
                 (ret = pc.TopNamespace.TryGetPackageAny(name)) == null) {
                 ret = TryImportSourceFile(pc, name);
@@ -737,7 +737,7 @@ namespace IronPython.Runtime {
 
             ret = MemberTrackerToPython(context, ret);
             if (ret != null) {
-                PythonContext.GetContext(context).SystemStateModules[name] = ret;
+                context.LanguageContext.SystemStateModules[name] = ret;
             }
             return ret;
         }
@@ -854,7 +854,7 @@ namespace IronPython.Runtime {
         private static object ImportFromPathHook(CodeContext/*!*/ context, string/*!*/ name, string/*!*/ fullName, List/*!*/ path, Func<CodeContext, string, string, string, object> defaultLoader) {
             Assert.NotNull(context, name, fullName, path);
 
-            IDictionary<object, object> importCache = PythonContext.GetContext(context).GetSystemStateValue("path_importer_cache") as IDictionary<object, object>;
+            IDictionary<object, object> importCache = context.LanguageContext.GetSystemStateValue("path_importer_cache") as IDictionary<object, object>;
 
             if (importCache == null) {
                 return null;
@@ -889,7 +889,7 @@ namespace IronPython.Runtime {
 
         internal static bool TryImportMainFromZip(CodeContext/*!*/ context, string/*!*/ path, out object importer) {
             Assert.NotNull(context, path);
-            var importCache = PythonContext.GetContext(context).GetSystemStateValue("path_importer_cache") as IDictionary<object, object>;
+            var importCache = context.LanguageContext.GetSystemStateValue("path_importer_cache") as IDictionary<object, object>;
             if (importCache == null) {
                 importer = null;
                 return false;
@@ -899,7 +899,7 @@ namespace IronPython.Runtime {
                 return false;
             }
             // for consistency with cpython, insert zip as a first entry into sys.path
-            var syspath = PythonContext.GetContext(context).GetSystemStateValue("path") as List;
+            var syspath = context.LanguageContext.GetSystemStateValue("path") as List;
             if (syspath != null) {
                 syspath.Insert(0, path);
             }
@@ -930,7 +930,7 @@ namespace IronPython.Runtime {
         /// handles this path.
         /// </summary>
         private static object FindImporterForPath(CodeContext/*!*/ context, string dirname) {
-            List pathHooks = PythonContext.GetContext(context).GetSystemStateValue("path_hooks") as List;
+            List pathHooks = context.LanguageContext.GetSystemStateValue("path_hooks") as List;
 
             foreach (object hook in (IEnumerable)pathHooks) {
                 try {
@@ -956,7 +956,7 @@ namespace IronPython.Runtime {
         private static PythonModule LoadModuleFromSource(CodeContext/*!*/ context, string/*!*/ name, string/*!*/ path) {
             Assert.NotNull(context, name, path);
 
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             string fullPath = GetFullPathAndValidateCase(pc, path, false);
             if (fullPath == null || !pc.DomainManager.Platform.FileExists(fullPath)) {
@@ -998,7 +998,7 @@ namespace IronPython.Runtime {
         internal static PythonModule LoadPackageFromSource(CodeContext/*!*/ context, string/*!*/ name, string/*!*/ path) {
             Assert.NotNull(context, name, path);
 
-            path = GetFullPathAndValidateCase(PythonContext.GetContext(context), path, true);
+            path = GetFullPathAndValidateCase(context.LanguageContext, path, true);
             if (path == null) {
                 return null;
             }
@@ -1012,7 +1012,7 @@ namespace IronPython.Runtime {
 
         private static PythonModule/*!*/ LoadFromSourceUnit(CodeContext/*!*/ context, SourceUnit/*!*/ sourceCode, string/*!*/ name, string/*!*/ path) {
             Assert.NotNull(sourceCode, name, path);
-            return PythonContext.GetContext(context).CompileModule(path, name, sourceCode, ModuleOptions.Initialize | ModuleOptions.Optimized);
+            return context.LanguageContext.CompileModule(path, name, sourceCode, ModuleOptions.Initialize | ModuleOptions.Optimized);
         }
     }
 }

--- a/Src/IronPython/Runtime/List.cs
+++ b/Src/IronPython/Runtime/List.cs
@@ -115,7 +115,7 @@ namespace IronPython.Runtime {
             try {
                 object len;
                 if (PythonTypeOps.TryInvokeUnaryOperator(context, sequence, "__len__", out len)) {
-                    int ilen = PythonContext.GetContext(context).ConvertToInt32(len);
+                    int ilen = context.LanguageContext.ConvertToInt32(len);
                     _data = new object[ilen];
                     _size = 0;
                     extend(sequence);
@@ -952,7 +952,7 @@ namespace IronPython.Runtime {
 
             // the empty list is already sorted
             if (_size != 0) {                
-                IComparer comparer = PythonContext.GetContext(context).GetComparer(
+                IComparer comparer = context.LanguageContext.GetComparer(
                     cmp,
                     GetComparisonType());
 

--- a/Src/IronPython/Runtime/Method.cs
+++ b/Src/IronPython/Runtime/Method.cs
@@ -97,12 +97,12 @@ namespace IronPython.Runtime {
 
         [SpecialName]
         public object Call(CodeContext/*!*/ context, params object[] args) {
-            return PythonContext.GetContext(context).CallSplat(this, args);
+            return context.LanguageContext.CallSplat(this, args);
         }
 
         [SpecialName]
         public object Call(CodeContext/*!*/ context, [ParamDictionary]IDictionary<object, object> kwArgs, params object[] args) {
-            return PythonContext.GetContext(context).CallWithKeywords(this, args, kwArgs);
+            return context.LanguageContext.CallWithKeywords(this, args, kwArgs);
         }
 
         private Exception BadSelf(object got) {

--- a/Src/IronPython/Runtime/ModuleLoader.cs
+++ b/Src/IronPython/Runtime/ModuleLoader.cs
@@ -30,7 +30,7 @@ namespace IronPython.Runtime {
         }
 
         public PythonModule load_module(CodeContext/*!*/ context, string fullName) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             CodeContext newContext = _sc.CreateContext();
             newContext.ModuleContext.InitializeBuiltins(false);

--- a/Src/IronPython/Runtime/ObjectAttributesAdapter.cs
+++ b/Src/IronPython/Runtime/ObjectAttributesAdapter.cs
@@ -35,7 +35,7 @@ namespace IronPython.Runtime {
         }
 
         public override void Add(ref DictionaryStorage storage, object key, object value) {
-            PythonContext.GetContext(_context).SetIndex(_backing, key, value);
+            _context.LanguageContext.SetIndex(_backing, key, value);
         }
 
         public override bool Contains(object key) {
@@ -45,7 +45,7 @@ namespace IronPython.Runtime {
 
         public override bool Remove(ref DictionaryStorage storage, object key) {
             try {
-                PythonContext.GetContext(_context).DelIndex(_backing, key);
+                _context.LanguageContext.DelIndex(_backing, key);
                 return true;
             } catch (KeyNotFoundException) {
                 return false;

--- a/Src/IronPython/Runtime/Operations/ArrayOps.cs
+++ b/Src/IronPython/Runtime/Operations/ArrayOps.cs
@@ -68,7 +68,7 @@ namespace IronPython.Runtime.Operations {
             if (!PythonOps.TryGetBoundAttr(items, "__len__", out lenFunc))
                 throw PythonOps.TypeErrorForBadInstance("expected object with __len__ function, got {0}", items);
 
-            int len = PythonContext.GetContext(context).ConvertToInt32(PythonOps.CallWithContext(context, lenFunc));
+            int len = context.LanguageContext.ConvertToInt32(PythonOps.CallWithContext(context, lenFunc));
 
             Array res = Array.CreateInstance(type, len);
 

--- a/Src/IronPython/Runtime/Operations/DelegateOps.cs
+++ b/Src/IronPython/Runtime/Operations/DelegateOps.cs
@@ -55,11 +55,11 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static object Call(CodeContext/*!*/ context, Delegate @delegate, params object[] args) {
-            return PythonContext.GetContext(context).CallSplat(@delegate, args);
+            return context.LanguageContext.CallSplat(@delegate, args);
         }
 
         public static object Call(CodeContext/*!*/ context, Delegate @delegate, [ParamDictionary]IDictionary<object, object> dict, params object[] args) {
-            return PythonContext.GetContext(context).CallWithKeywords(@delegate, args, dict);
+            return context.LanguageContext.CallWithKeywords(@delegate, args, dict);
         }
 
     }

--- a/Src/IronPython/Runtime/Operations/FloatOps.cs
+++ b/Src/IronPython/Runtime/Operations/FloatOps.cs
@@ -774,10 +774,10 @@ namespace IronPython.Runtime.Operations {
             FloatFormat res;
             switch (typestr) {
                 case "float":
-                    res = PythonContext.GetContext(context).FloatFormat;
+                    res = context.LanguageContext.FloatFormat;
                     break;
                 case "double":
-                    res = PythonContext.GetContext(context).DoubleFormat;
+                    res = context.LanguageContext.DoubleFormat;
                     break;
                 default:
                     throw PythonOps.ValueError("__getformat__() argument 1 must be 'double' or 'float'");
@@ -935,7 +935,7 @@ namespace IronPython.Runtime.Operations {
                             }
 
                             string fmt;
-                            if (spec.Type == 'n' && PythonContext.GetContext(context).NumericCulture != PythonContext.CCulture) {
+                            if (spec.Type == 'n' && context.LanguageContext.NumericCulture != PythonContext.CCulture) {
                                 // we've already figured out, we don't have any digits for decimal points, so just format as a number + exponent
                                 fmt = "0";
                             } else if (spec.Precision > 1 || digitCnt > 6) {
@@ -961,7 +961,7 @@ namespace IronPython.Runtime.Operations {
 
                             self = MathUtils.RoundAwayFromZero(self, decimalPoints);
 
-                            if (spec.Type == 'n' && PythonContext.GetContext(context).NumericCulture != PythonContext.CCulture) {
+                            if (spec.Type == 'n' && context.LanguageContext.NumericCulture != PythonContext.CCulture) {
                                 if (digitCnt != precision && (self % 1) != 0) {
                                     digits = self.ToString("#,0.0" + new string('#', decimalPoints));
                                 } else {
@@ -1022,10 +1022,10 @@ namespace IronPython.Runtime.Operations {
 
             switch (typestr) {
                 case "float":
-                    PythonContext.GetContext(context).FloatFormat = format;
+                    context.LanguageContext.FloatFormat = format;
                     break;
                 case "double":
-                    PythonContext.GetContext(context).DoubleFormat = format;
+                    context.LanguageContext.DoubleFormat = format;
                     break;
                 default:
                     throw PythonOps.ValueError("__setformat__() argument 1 must be 'double' or 'float'");

--- a/Src/IronPython/Runtime/Operations/InstanceOps.cs
+++ b/Src/IronPython/Runtime/Operations/InstanceOps.cs
@@ -405,17 +405,17 @@ namespace IronPython.Runtime.Operations {
         // Structural Equality and Hashing Helpers
 
         public static int StructuralHashMethod(CodeContext/*!*/ context, IStructuralEquatable x) {
-            return x.GetHashCode(PythonContext.GetContext(context).EqualityComparerNonGeneric);
+            return x.GetHashCode(context.LanguageContext.EqualityComparerNonGeneric);
         }
 
         public static bool StructuralEqualityMethod<T>(CodeContext/*!*/ context, T x, [NotNull]T y)
             where T : IStructuralEquatable {
-            return x.Equals(y, PythonContext.GetContext(context).EqualityComparerNonGeneric);
+            return x.Equals(y, context.LanguageContext.EqualityComparerNonGeneric);
         }
 
         public static bool StructuralInequalityMethod<T>(CodeContext/*!*/ context, T x, [NotNull]T y)
             where T : IStructuralEquatable {
-            return !x.Equals(y, PythonContext.GetContext(context).EqualityComparerNonGeneric);
+            return !x.Equals(y, context.LanguageContext.EqualityComparerNonGeneric);
         }
 
         [return: MaybeNotImplemented]
@@ -424,7 +424,7 @@ namespace IronPython.Runtime.Operations {
             if (!(y is T)) return NotImplementedType.Value;
 
             return ScriptingRuntimeHelpers.BooleanToObject(
-                x.Equals(y, PythonContext.GetContext(context).EqualityComparerNonGeneric)
+                x.Equals(y, context.LanguageContext.EqualityComparerNonGeneric)
             );
         }
 
@@ -434,7 +434,7 @@ namespace IronPython.Runtime.Operations {
             if (!(y is T)) return NotImplementedType.Value;
 
             return ScriptingRuntimeHelpers.BooleanToObject(
-                !x.Equals(y, PythonContext.GetContext(context).EqualityComparerNonGeneric)
+                !x.Equals(y, context.LanguageContext.EqualityComparerNonGeneric)
             );
         }
 
@@ -444,7 +444,7 @@ namespace IronPython.Runtime.Operations {
             if (!(y is T)) return NotImplementedType.Value;
 
             return ScriptingRuntimeHelpers.BooleanToObject(
-                x.Equals(y, PythonContext.GetContext(context).EqualityComparerNonGeneric)
+                x.Equals(y, context.LanguageContext.EqualityComparerNonGeneric)
             );
         }
 
@@ -454,14 +454,14 @@ namespace IronPython.Runtime.Operations {
             if (!(y is T)) return NotImplementedType.Value;
 
             return ScriptingRuntimeHelpers.BooleanToObject(
-                !x.Equals(y, PythonContext.GetContext(context).EqualityComparerNonGeneric)
+                !x.Equals(y, context.LanguageContext.EqualityComparerNonGeneric)
             );
         }
 
         // Structural Comparison Helpers
 
         private static int StructuralCompare(CodeContext/*!*/ context, IStructuralComparable x, object y) {
-            return x.CompareTo(y, PythonContext.GetContext(context).GetComparer(null, null));
+            return x.CompareTo(y, context.LanguageContext.GetComparer(null, null));
         }
 
         public static bool StructuralComparableEquality<T>(CodeContext/*!*/ context, T x, [NotNull]T y)
@@ -893,7 +893,7 @@ namespace IronPython.Runtime.Operations {
             PythonTuple data = ClrModule.Serialize(self);
 
             object deserializeNew;
-            bool res = PythonContext.GetContext(context).ClrModule.__dict__.TryGetValue(
+            bool res = context.LanguageContext.ClrModule.__dict__.TryGetValue(
                 "Deserialize",
                 out deserializeNew
             );

--- a/Src/IronPython/Runtime/Operations/IntOps.cs
+++ b/Src/IronPython/Runtime/Operations/IntOps.cs
@@ -439,7 +439,7 @@ namespace IronPython.Runtime.Operations {
 
             switch (spec.Type) {
                 case 'n':
-                    CultureInfo culture = PythonContext.GetContext(context).NumericCulture;
+                    CultureInfo culture = context.LanguageContext.NumericCulture;
 
                     if (culture == CultureInfo.InvariantCulture) {
                         // invariant culture maps to CPython's C culture, which doesn't

--- a/Src/IronPython/Runtime/Operations/LongOps.cs
+++ b/Src/IronPython/Runtime/Operations/LongOps.cs
@@ -1026,7 +1026,7 @@ namespace IronPython.Runtime.Operations {
             
             switch (spec.Type) {
                 case 'n':
-                    CultureInfo culture = PythonContext.GetContext(context).NumericCulture;
+                    CultureInfo culture = context.LanguageContext.NumericCulture;
 
                     if (culture == CultureInfo.InvariantCulture) {
                         // invariant culture maps to CPython's C culture, which doesn't
@@ -1034,7 +1034,7 @@ namespace IronPython.Runtime.Operations {
                         goto case 'd';
                     }
 
-                    digits = FormattingHelper.ToCultureString(val, PythonContext.GetContext(context).NumericCulture.NumberFormat, spec);
+                    digits = FormattingHelper.ToCultureString(val, context.LanguageContext.NumericCulture.NumberFormat, spec);
                     break;
 #if !FEATURE_NUMERICS
                 case null:

--- a/Src/IronPython/Runtime/Operations/NamespaceTrackerOps.cs
+++ b/Src/IronPython/Runtime/Operations/NamespaceTrackerOps.cs
@@ -86,7 +86,7 @@ namespace IronPython.Runtime.Operations {
                     return mt;
                 }
 
-                PythonTypeSlot pts = PythonTypeOps.GetSlot(new MemberGroup(mt), name, PythonContext.GetContext(context).Binder.PrivateBinding);
+                PythonTypeSlot pts = PythonTypeOps.GetSlot(new MemberGroup(mt), name, context.LanguageContext.Binder.PrivateBinding);
                 object value;
                 if (pts != null && pts.TryGetValue(context, null, TypeCache.PythonType, out value)) {
                     return value;

--- a/Src/IronPython/Runtime/Operations/ObjectOps.cs
+++ b/Src/IronPython/Runtime/Operations/ObjectOps.cs
@@ -163,7 +163,7 @@ namespace IronPython.Runtime.Operations {
                 }
             }
 
-            if (PythonContext.GetContext(context).ConvertToInt32(protocol) < 2) {
+            if (context.LanguageContext.ConvertToInt32(protocol) < 2) {
                 return ReduceProtocol0(context, self);
             } else {
                 return ReduceProtocol2(context, self);
@@ -359,7 +359,7 @@ namespace IronPython.Runtime.Operations {
 
             PythonType closestNonPythonBase = FindClosestNonPythonBase(myType); // PEP 307 calls this "B"
 
-            object func = PythonContext.GetContext(context).PythonReconstructor;
+            object func = context.LanguageContext.PythonReconstructor;
 
             object funcArgs = PythonTuple.MakeTuple(
                 myType,
@@ -410,7 +410,7 @@ namespace IronPython.Runtime.Operations {
             object func, state, listIterator, dictIterator;
             object[] funcArgs;
 
-            func = PythonContext.GetContext(context).NewObject;
+            func = context.LanguageContext.NewObject;
 
             object getNewArgsCallable;
             if (PythonOps.TryGetBoundAttr(context, myType, "__getnewargs__", out getNewArgsCallable)) {

--- a/Src/IronPython/Runtime/Operations/PythonCalls.cs
+++ b/Src/IronPython/Runtime/Operations/PythonCalls.cs
@@ -23,19 +23,19 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static object Call(CodeContext context, object func) {
-            return PythonContext.GetContext(context).Call(context, func);
+            return context.LanguageContext.Call(context, func);
         }
 
         public static object Call(CodeContext/*!*/ context, object func, object arg0) {
-            return PythonContext.GetContext(context).Call(context, func, arg0);
+            return context.LanguageContext.Call(context, func, arg0);
         }
 
         public static object Call(CodeContext/*!*/ context, object func, object arg0, object arg1) {
-            return PythonContext.GetContext(context).Call(context, func, arg0, arg1);
+            return context.LanguageContext.Call(context, func, arg0, arg1);
         }
 
         public static object Call(CodeContext/*!*/ context, object func, params object[] args) {
-            return PythonContext.GetContext(context).CallSplat(func, args);
+            return context.LanguageContext.CallSplat(func, args);
         }
 
         public static object CallWithKeywordArgs(CodeContext/*!*/ context, object func, object[] args, string[] names) {
@@ -52,7 +52,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static object CallWithKeywordArgs(CodeContext context, object func, object[] args, IDictionary<object, object> dict) {
-            return PythonContext.GetContext(context).CallWithKeywords(func, args, dict);
+            return context.LanguageContext.CallWithKeywords(func, args, dict);
         }        
     }
 }

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -132,7 +132,7 @@ namespace IronPython.Runtime.Operations {
 
 
             // Invoke Operator.IsCallable on the object. 
-            return PythonContext.GetContext(context).IsCallable(o);
+            return context.LanguageContext.IsCallable(o);
         }
 
         public static bool UserObjectIsCallable(CodeContext/*!*/ context, object o) {
@@ -154,7 +154,7 @@ namespace IronPython.Runtime.Operations {
 
         [LightThrowing]
         internal static object LookupEncodingError(CodeContext/*!*/ context, string name) {
-            Dictionary<string, object> errorHandlers = PythonContext.GetContext(context).ErrorHandlers;
+            Dictionary<string, object> errorHandlers = context.LanguageContext.ErrorHandlers;
             lock (errorHandlers) {
                 if (errorHandlers.ContainsKey(name))
                     return errorHandlers[name];
@@ -164,7 +164,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static void RegisterEncodingError(CodeContext/*!*/ context, string name, object handler) {
-            Dictionary<string, object> errorHandlers = PythonContext.GetContext(context).ErrorHandlers;
+            Dictionary<string, object> errorHandlers = context.LanguageContext.ErrorHandlers;
 
             lock (errorHandlers) {
                 if (!PythonOps.IsCallable(context, handler))
@@ -175,9 +175,9 @@ namespace IronPython.Runtime.Operations {
         }
 
         internal static PythonTuple LookupEncoding(CodeContext/*!*/ context, string encoding) {
-            PythonContext.GetContext(context).EnsureEncodings();
+            context.LanguageContext.EnsureEncodings();
 
-            List<object> searchFunctions = PythonContext.GetContext(context).SearchFunctions;
+            List<object> searchFunctions = context.LanguageContext.SearchFunctions;
             string normalized = encoding.ToLower().Replace(' ', '-');
             if (normalized.IndexOf(Char.MinValue) != -1) {
                 throw PythonOps.TypeError("lookup string cannot contain null character");
@@ -196,7 +196,7 @@ namespace IronPython.Runtime.Operations {
             if (!PythonOps.IsCallable(context, search_function))
                 throw PythonOps.TypeError("search_function must be callable");
 
-            List<object> searchFunctions = PythonContext.GetContext(context).SearchFunctions;
+            List<object> searchFunctions = context.LanguageContext.SearchFunctions;
 
             lock (searchFunctions) {
                 searchFunctions.Add(search_function);
@@ -337,7 +337,7 @@ namespace IronPython.Runtime.Operations {
             if (typeinfo == null) throw PythonOps.TypeError("issubclass: arg 2 must be a class");
 
             PythonTuple pt = typeinfo as PythonTuple;
-            PythonContext pyContext = PythonContext.GetContext(context);
+            PythonContext pyContext = context.LanguageContext;
             if (pt != null) {
                 // Recursively inspect nested tuple(s)
                 foreach (object o in pt) {
@@ -406,7 +406,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static bool IsInstance(CodeContext/*!*/ context, object o, PythonTuple typeinfo) {
-            PythonContext pyContext = PythonContext.GetContext(context);
+            PythonContext pyContext = context.LanguageContext;
             foreach (object type in typeinfo) {
                 try {
                     PythonOps.FunctionPushFrame(pyContext);
@@ -579,7 +579,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static object Equal(CodeContext/*!*/ context, object x, object y) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             return pc.EqualSite.Target(pc.EqualSite, x, y);
         }
 
@@ -677,7 +677,7 @@ namespace IronPython.Runtime.Operations {
             int diff;
 
             if (DynamicHelpers.GetPythonType(x) != DynamicHelpers.GetPythonType(y)) {
-                if (shouldWarn && PythonContext.GetContext(context).PythonOptions.WarnPython30) {
+                if (shouldWarn && context.LanguageContext.PythonOptions.WarnPython30) {
                     PythonOps.Warn(context, PythonExceptions.DeprecationWarning, "comparing unequal types not supported in 3.x");
                 }
 
@@ -803,7 +803,7 @@ namespace IronPython.Runtime.Operations {
         public static object PowerMod(CodeContext/*!*/ context, object x, object y, object z) {
             object ret;
             if (z == null) {
-                return PythonContext.GetContext(context).Operation(PythonOperationKind.Power, x, y);
+                return context.LanguageContext.Operation(PythonOperationKind.Power, x, y);
             }
             if (x is int && y is int && z is int) {
                 ret = Int32Ops.Power((int)x, (int)y, (int)z);
@@ -1057,7 +1057,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static object GetIndex(CodeContext/*!*/ context, object o, object index) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             return pc.GetIndexSite.Target(pc.GetIndexSite, o, index);
         }
 
@@ -1066,7 +1066,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static void SetAttr(CodeContext/*!*/ context, object o, string name, object value) {
-            PythonContext.GetContext(context).SetAttr(context, o, name, value);
+            context.LanguageContext.SetAttr(context, o, name, value);
         }
 
         public static bool TryGetBoundAttr(CodeContext/*!*/ context, object o, string name, out object ret) {
@@ -1074,7 +1074,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static void DeleteAttr(CodeContext/*!*/ context, object o, string name) {
-            PythonContext.GetContext(context).DeleteAttr(context, o, name);
+            context.LanguageContext.DeleteAttr(context, o, name);
         }
 
         public static bool HasAttr(CodeContext/*!*/ context, object o, string name) {
@@ -1503,7 +1503,7 @@ namespace IronPython.Runtime.Operations {
             // __metaclass__ = foo
             // class bar: pass
             // calls our function...
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             return pc.MetaClassCallSite.Target(
                 pc.MetaClassCallSite,
@@ -1520,7 +1520,7 @@ namespace IronPython.Runtime.Operations {
         /// </summary>
         /// <param name="msg">Object representing the assertion message</param>
         public static void RaiseAssertionError(CodeContext context, object msg) {
-            PythonDictionary builtins = context.GetBuiltinsDict() ?? PythonContext.GetContext(context).BuiltinModuleDict;
+            PythonDictionary builtins = context.GetBuiltinsDict() ?? context.LanguageContext.BuiltinModuleDict;
 
             object obj;
             var message = String.Empty;
@@ -1690,7 +1690,7 @@ namespace IronPython.Runtime.Operations {
         #region Standard I/O support
 
         public static void Write(CodeContext/*!*/ context, object f, string text) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             if (f == null) {
                 f = pc.SystemStandardOut;
@@ -1747,11 +1747,11 @@ namespace IronPython.Runtime.Operations {
 
         // Must stay here for now because libs depend on it.
         public static void Print(CodeContext/*!*/ context, object o) {
-            PrintWithDest(context, PythonContext.GetContext(context).SystemStandardOut, o);
+            PrintWithDest(context, context.LanguageContext.SystemStandardOut, o);
         }
 
         public static void PrintNoNewline(CodeContext/*!*/ context, object o) {
-            PrintWithDestNoNewline(context, PythonContext.GetContext(context).SystemStandardOut, o);
+            PrintWithDestNoNewline(context, context.LanguageContext.SystemStandardOut, o);
         }
 
         public static void PrintWithDest(CodeContext/*!*/ context, object dest, object o) {
@@ -1772,7 +1772,7 @@ namespace IronPython.Runtime.Operations {
         /// Prints newline into default standard output
         /// </summary>
         public static void PrintNewline(CodeContext/*!*/ context) {
-            PrintNewlineWithDest(context, PythonContext.GetContext(context).SystemStandardOut);
+            PrintNewlineWithDest(context, context.LanguageContext.SystemStandardOut);
         }
 
         /// <summary>
@@ -1787,7 +1787,7 @@ namespace IronPython.Runtime.Operations {
         /// Prints value into default standard output with Python comma semantics.
         /// </summary>
         public static void PrintComma(CodeContext/*!*/ context, object o) {
-            PrintCommaWithDest(context, PythonContext.GetContext(context).SystemStandardOut, o);
+            PrintCommaWithDest(context, context.LanguageContext.SystemStandardOut, o);
         }
 
         /// <summary>
@@ -1805,14 +1805,14 @@ namespace IronPython.Runtime.Operations {
         /// Called from generated code when we are supposed to print an expression value
         /// </summary>
         public static void PrintExpressionValue(CodeContext/*!*/ context, object value) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             object dispHook = pc.GetSystemStateValue("displayhook");
             pc.CallWithContext(context, dispHook, value);
         }
 
 #if FEATURE_FULL_CONSOLE
         public static void PrintException(CodeContext/*!*/ context, Exception/*!*/ exception, IConsole console) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             PythonTuple exInfo = GetExceptionInfoLocal(context, exception);
             pc.SetSystemStateValue("last_type", exInfo[0]);
             pc.SetSystemStateValue("last_value", exInfo[1]);
@@ -2006,7 +2006,7 @@ namespace IronPython.Runtime.Operations {
             PythonFile pf;
             Stream cs;
 
-            var pythonContext = PythonContext.GetContext(context);
+            var pythonContext = context.LanguageContext;
 
             bool noLineFeed = true;
 
@@ -2136,7 +2136,7 @@ namespace IronPython.Runtime.Operations {
             }
 
             IEnumerable enumer;
-            if (PythonContext.GetContext(context).TryConvertToIEnumerable(enumerable, out enumer)) {
+            if (context.LanguageContext.TryConvertToIEnumerable(enumerable, out enumer)) {
                 enumerator = enumer.GetEnumerator();
                 return true;
             }
@@ -2893,7 +2893,7 @@ namespace IronPython.Runtime.Operations {
             if (self.TryGetBoundCustomMember(context, "__iter__", out callable)) {
                 return CreatePythonEnumerable(self);
             } else if (self.TryGetBoundCustomMember(context, "__getitem__", out callable)) {
-                return CreateItemEnumerable(callable, PythonContext.GetContext(context).GetItemCallSite);
+                return CreateItemEnumerable(callable, context.LanguageContext.GetItemCallSite);
             }
 
             return null;
@@ -2913,7 +2913,7 @@ namespace IronPython.Runtime.Operations {
             if (self.TryGetBoundCustomMember(context, "__iter__", out callable)) {
                 return new IEnumerableOfTWrapper<T>(CreatePythonEnumerable(self));
             } else if (self.TryGetBoundCustomMember(context, "__getitem__", out callable)) {
-                return new IEnumerableOfTWrapper<T>(CreateItemEnumerable(callable, PythonContext.GetContext(context).GetItemCallSite));
+                return new IEnumerableOfTWrapper<T>(CreateItemEnumerable(callable, context.LanguageContext.GetItemCallSite));
             }
 
             return null;
@@ -2933,7 +2933,7 @@ namespace IronPython.Runtime.Operations {
             if (self.TryGetBoundCustomMember(context, "__iter__", out callable)) {
                 return CreatePythonEnumerator(self);
             } else if (self.TryGetBoundCustomMember(context, "__getitem__", out callable)) {
-                return CreateItemEnumerator(callable, PythonContext.GetContext(context).GetItemCallSite);
+                return CreateItemEnumerator(callable, context.LanguageContext.GetItemCallSite);
             }
 
             return null;
@@ -2972,7 +2972,7 @@ namespace IronPython.Runtime.Operations {
             if (oi.TryGetBoundCustomMember(context, "__nonzero__", out value)) {
                 return ThrowingConvertToNonZero(PythonCalls.Call(context, value));
             } else if (oi.TryGetBoundCustomMember(context, "__len__", out value)) {
-                return PythonContext.GetContext(context).ConvertToInt32(PythonCalls.Call(context, value)) != 0;
+                return context.LanguageContext.ConvertToInt32(PythonCalls.Call(context, value)) != 0;
             }
 
             return null;
@@ -3237,7 +3237,7 @@ namespace IronPython.Runtime.Operations {
 
         [NoSideEffects]
         public static object MakeFunctionDebug(CodeContext/*!*/ context, FunctionCode funcInfo, object modName, object[] defaults, Delegate target) {
-            funcInfo.SetDebugTarget(PythonContext.GetContext(context), target);
+            funcInfo.SetDebugTarget(context.LanguageContext, target);
 
             return new PythonFunction(context, funcInfo, modName, defaults, null);
         }
@@ -3273,7 +3273,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static void FunctionPushFrameCodeContext(CodeContext context) {
-            FunctionPushFrame(PythonContext.GetContext(context));
+            FunctionPushFrame(context.LanguageContext);
         }
 
         public static void FunctionPopFrame() {
@@ -3561,9 +3561,9 @@ namespace IronPython.Runtime.Operations {
 
         public static void RemoveModule(CodeContext/*!*/ context, string name, object oldValue) {
             if (oldValue != null) {
-                PythonContext.GetContext(context).SystemStateModules[name] = oldValue;
+                context.LanguageContext.SystemStateModules[name] = oldValue;
             } else {
-                PythonContext.GetContext(context).SystemStateModules.Remove(name);
+                context.LanguageContext.SystemStateModules.Remove(name);
             }
         }
 
@@ -3597,7 +3597,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static void Warn(CodeContext/*!*/ context, PythonType category, string message, params object[] args) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             object warnings = pc.GetWarningsModule(), warn = null;
 
             if (warnings != null) {
@@ -3620,7 +3620,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static void ShowWarning(CodeContext/*!*/ context, PythonType category, string message, string filename, int lineNo) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             object warnings = pc.GetWarningsModule(), warn = null;
 
             if (warnings != null) {
@@ -3678,79 +3678,79 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static DynamicMetaObjectBinder MakeComboAction(CodeContext/*!*/ context, DynamicMetaObjectBinder opBinder, DynamicMetaObjectBinder convBinder) {
-            return PythonContext.GetContext(context).BinaryOperationRetType((PythonBinaryOperationBinder)opBinder, (PythonConversionBinder)convBinder);
+            return context.LanguageContext.BinaryOperationRetType((PythonBinaryOperationBinder)opBinder, (PythonConversionBinder)convBinder);
         }
 
         public static DynamicMetaObjectBinder MakeInvokeAction(CodeContext/*!*/ context, CallSignature signature) {
-            return PythonContext.GetContext(context).Invoke(signature);
+            return context.LanguageContext.Invoke(signature);
         }
 
         public static DynamicMetaObjectBinder MakeGetAction(CodeContext/*!*/ context, string name, bool isNoThrow) {
-            return PythonContext.GetContext(context).GetMember(name);
+            return context.LanguageContext.GetMember(name);
         }
 
         public static DynamicMetaObjectBinder MakeCompatGetAction(CodeContext/*!*/ context, string name) {
-            return PythonContext.GetContext(context).CompatGetMember(name, false);
+            return context.LanguageContext.CompatGetMember(name, false);
         }
 
         public static DynamicMetaObjectBinder MakeCompatInvokeAction(CodeContext/*!*/ context, CallInfo callInfo) {
-            return PythonContext.GetContext(context).CompatInvoke(callInfo);
+            return context.LanguageContext.CompatInvoke(callInfo);
         }
 
         public static DynamicMetaObjectBinder MakeCompatConvertAction(CodeContext/*!*/ context, Type toType, bool isExplicit) {
-            return PythonContext.GetContext(context).Convert(toType, isExplicit ? ConversionResultKind.ExplicitCast : ConversionResultKind.ImplicitCast).CompatBinder;
+            return context.LanguageContext.Convert(toType, isExplicit ? ConversionResultKind.ExplicitCast : ConversionResultKind.ImplicitCast).CompatBinder;
         }
 
         public static DynamicMetaObjectBinder MakeSetAction(CodeContext/*!*/ context, string name) {
-            return PythonContext.GetContext(context).SetMember(name);
+            return context.LanguageContext.SetMember(name);
         }
 
         public static DynamicMetaObjectBinder MakeDeleteAction(CodeContext/*!*/ context, string name) {
-            return PythonContext.GetContext(context).DeleteMember(name);
+            return context.LanguageContext.DeleteMember(name);
         }
 
         public static DynamicMetaObjectBinder MakeConversionAction(CodeContext/*!*/ context, Type type, ConversionResultKind kind) {
-            return PythonContext.GetContext(context).Convert(type, kind);
+            return context.LanguageContext.Convert(type, kind);
         }
 
         public static DynamicMetaObjectBinder MakeTryConversionAction(CodeContext/*!*/ context, Type type, ConversionResultKind kind) {
-            return PythonContext.GetContext(context).Convert(type, kind);
+            return context.LanguageContext.Convert(type, kind);
         }
 
         public static DynamicMetaObjectBinder MakeOperationAction(CodeContext/*!*/ context, int operationName) {
-            return PythonContext.GetContext(context).Operation((PythonOperationKind)operationName);
+            return context.LanguageContext.Operation((PythonOperationKind)operationName);
         }
 
         public static DynamicMetaObjectBinder MakeUnaryOperationAction(CodeContext/*!*/ context, ExpressionType expressionType) {
-            return PythonContext.GetContext(context).UnaryOperation(expressionType);
+            return context.LanguageContext.UnaryOperation(expressionType);
         }
 
         public static DynamicMetaObjectBinder MakeBinaryOperationAction(CodeContext/*!*/ context, ExpressionType expressionType) {
-            return PythonContext.GetContext(context).BinaryOperation(expressionType);
+            return context.LanguageContext.BinaryOperation(expressionType);
         }
 
         public static DynamicMetaObjectBinder MakeGetIndexAction(CodeContext/*!*/ context, int argCount) {
-            return PythonContext.GetContext(context).GetIndex(argCount);
+            return context.LanguageContext.GetIndex(argCount);
         }
 
         public static DynamicMetaObjectBinder MakeSetIndexAction(CodeContext/*!*/ context, int argCount) {
-            return PythonContext.GetContext(context).SetIndex(argCount);
+            return context.LanguageContext.SetIndex(argCount);
         }
 
         public static DynamicMetaObjectBinder MakeDeleteIndexAction(CodeContext/*!*/ context, int argCount) {
-            return PythonContext.GetContext(context).DeleteIndex(argCount);
+            return context.LanguageContext.DeleteIndex(argCount);
         }
 
         public static DynamicMetaObjectBinder MakeGetSliceBinder(CodeContext/*!*/ context) {
-            return PythonContext.GetContext(context).GetSlice;
+            return context.LanguageContext.GetSlice;
         }
 
         public static DynamicMetaObjectBinder MakeSetSliceBinder(CodeContext/*!*/ context) {
-            return PythonContext.GetContext(context).SetSliceBinder;
+            return context.LanguageContext.SetSliceBinder;
         }
 
         public static DynamicMetaObjectBinder MakeDeleteSliceBinder(CodeContext/*!*/ context) {
-            return PythonContext.GetContext(context).DeleteSlice;
+            return context.LanguageContext.DeleteSlice;
         }
 
 #if FEATURE_REFEMIT

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -1414,7 +1414,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static void InitializeForFinalization(CodeContext/*!*/ context, object newObject) {
-            IWeakReferenceable iwr = context.GetPythonContext().ConvertToWeakReferenceable(newObject);
+            IWeakReferenceable iwr = context.LanguageContext.ConvertToWeakReferenceable(newObject);
             Debug.Assert(iwr != null);
 
             InstanceFinalizer nif = new InstanceFinalizer(context, newObject);
@@ -3614,7 +3614,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         public static void Warn3k(CodeContext/*!*/ context, string message, params object[] args) {
-            if (context.GetPythonContext().PythonOptions.WarnPython30) {
+            if (context.LanguageContext.PythonOptions.WarnPython30) {
                 Warn(context, PythonExceptions.DeprecationWarning, message, args);
             }
         }

--- a/Src/IronPython/Runtime/Operations/PythonTypeOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonTypeOps.cs
@@ -56,7 +56,7 @@ namespace IronPython.Runtime.Operations {
             Type curType = type;
             while (curType != null) {
                 string moduleName;
-                if (PythonContext.GetContext(context).BuiltinModuleNames.TryGetValue(curType, out moduleName)) {
+                if (context.LanguageContext.BuiltinModuleNames.TryGetValue(curType, out moduleName)) {
                     return moduleName;
                 }
 

--- a/Src/IronPython/Runtime/Operations/PythonTypeOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonTypeOps.cs
@@ -155,7 +155,7 @@ namespace IronPython.Runtime.Operations {
             // check if object has finalizer...
             PythonTypeSlot dummy;
             if (dt.TryResolveSlot(context, "__del__", out dummy)) {
-                IWeakReferenceable iwr = context.GetPythonContext().ConvertToWeakReferenceable(newObject);
+                IWeakReferenceable iwr = context.LanguageContext.ConvertToWeakReferenceable(newObject);
                 Debug.Assert(iwr != null);
 
                 InstanceFinalizer nif = new InstanceFinalizer(context, newObject);

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -400,7 +400,7 @@ namespace IronPython.Runtime.Operations {
             if (str == null) throw PythonOps.TypeError("converting to unicode: need string, got {0}", DynamicHelpers.GetPythonType(@string).Name);
 
             if (cls == TypeCache.String) {
-                return decode(context, str, encoding ?? PythonContext.GetContext(context).GetDefaultEncodingName(), errors);
+                return decode(context, str, encoding ?? context.LanguageContext.GetDefaultEncodingName(), errors);
             } else {
                 return cls.CreateInstance(context, __new__(context, TypeCache.String, str, encoding, errors));
             }
@@ -1303,7 +1303,7 @@ namespace IronPython.Runtime.Operations {
         /// </summary>
         public static string/*!*/ format(CodeContext/*!*/ context, string format_string, [NotNull]params object[] args) {
             return NewStringFormatter.FormatString(
-                PythonContext.GetContext(context),
+                context.LanguageContext,
                 format_string,
                 PythonTuple.MakeTuple(args),
                 new PythonDictionary()
@@ -1322,7 +1322,7 @@ namespace IronPython.Runtime.Operations {
         /// </summary>
         public static string/*!*/ format(CodeContext/*!*/ context, string format_string\u00F8, [ParamDictionary]IDictionary<object, object> kwargs\u00F8, params object[] args\u00F8) {
             return NewStringFormatter.FormatString(
-                PythonContext.GetContext(context),
+                context.LanguageContext,
                 format_string\u00F8,
                 PythonTuple.MakeTuple(args\u00F8),
                 kwargs\u00F8
@@ -1704,7 +1704,7 @@ namespace IronPython.Runtime.Operations {
         }
 
         private static string RawDecode(CodeContext/*!*/ context, string s, object encodingType, string errors) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
 
             Encoding e = null;
             string encoding = encodingType as string;
@@ -1831,7 +1831,7 @@ namespace IronPython.Runtime.Operations {
                 e = encodingType as Encoding;
                 if (e == null) {
                     if (encodingType == Missing.Value) {
-                        encoding = PythonContext.GetContext(context).GetDefaultEncodingName();
+                        encoding = context.LanguageContext.GetDefaultEncodingName();
                     } else {
                         throw PythonOps.TypeError("encode() expected string, got '{0}'", DynamicHelpers.GetPythonType(encodingType).Name);
                     }

--- a/Src/IronPython/Runtime/Operations/UserTypeOps.cs
+++ b/Src/IronPython/Runtime/Operations/UserTypeOps.cs
@@ -363,7 +363,7 @@ namespace IronPython.Runtime.Operations {
 
         private static CallSite<Func<CallSite, CodeContext, object, string, object>> MakeGetAttrSite(CodeContext context) {
             return CallSite<Func<CallSite, CodeContext, object, string, object>>.Create(
-                PythonContext.GetContext(context).InvokeOne
+                context.LanguageContext.InvokeOne
             );
         }
 

--- a/Src/IronPython/Runtime/PythonBuffer.cs
+++ b/Src/IronPython/Runtime/PythonBuffer.cs
@@ -206,7 +206,7 @@ namespace IronPython.Runtime {
         }
 
         public static object operator +(PythonBuffer a, PythonBuffer b) {
-            PythonContext context = PythonContext.GetContext(a._context);
+            PythonContext context = a._context.LanguageContext;
 
             return context.Operation(
                 PythonOperationKind.Add,
@@ -220,7 +220,7 @@ namespace IronPython.Runtime {
         }
 
         public static object operator *(PythonBuffer b, int n) {
-            PythonContext context = PythonContext.GetContext(b._context);
+            PythonContext context = b._context.LanguageContext;
 
             return context.Operation(
                 PythonOperationKind.Multiply,
@@ -230,7 +230,7 @@ namespace IronPython.Runtime {
         }
 
         public static object operator *(int n, PythonBuffer b) {
-            PythonContext context = PythonContext.GetContext(b._context);
+            PythonContext context = b._context.LanguageContext;
 
             return context.Operation(
                 PythonOperationKind.Multiply,

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -1698,11 +1698,6 @@ namespace IronPython.Runtime
 
 #endregion
         
-        // TODO: Replace all usages with direct access
-        internal static PythonContext/*!*/ GetContext(CodeContext/*!*/ context) {
-            return context.LanguageContext;
-        }
-       
         public override TService GetService<TService>(params object[] args) {
             if (typeof(TService) == typeof(TokenizerService)) {
                 return (TService)(object)new Tokenizer(ErrorSink.Null, GetPythonCompilerOptions(), true);
@@ -2336,7 +2331,7 @@ namespace IronPython.Runtime
 
         internal static object InvokeUnaryOperator(CodeContext/*!*/ context, UnaryOperators oper, object target, string errorMsg) {
             object res;
-            if (PythonContext.GetContext(context).InvokeOperatorWorker(context, oper, target, out res)) {
+            if (context.LanguageContext.InvokeOperatorWorker(context, oper, target, out res)) {
                 return res;
             }
 
@@ -2345,7 +2340,7 @@ namespace IronPython.Runtime
 
         internal static object InvokeUnaryOperator(CodeContext/*!*/ context, UnaryOperators oper, object target) {
             object res;
-            if (PythonContext.GetContext(context).InvokeOperatorWorker(context, oper, target, out res)) {
+            if (context.LanguageContext.InvokeOperatorWorker(context, oper, target, out res)) {
                 return res;
             }
 
@@ -2353,7 +2348,7 @@ namespace IronPython.Runtime
         }
 
         internal static bool TryInvokeTernaryOperator(CodeContext/*!*/ context, TernaryOperators oper, object target, object value1, object value2, out object res) {
-            return PythonContext.GetContext(context).InvokeOperatorWorker(context, oper, target, value1, value2, out res);
+            return context.LanguageContext.InvokeOperatorWorker(context, oper, target, value1, value2, out res);
         }
 
         internal CallSite<Func<CallSite, object, object, int>> CompareSite {
@@ -4271,7 +4266,7 @@ namespace IronPython.Runtime
 
     public static class PythonContextHelpers {
         public static PythonContext GetPythonContext(this CodeContext context) {
-            return PythonContext.GetContext(context);
+            return context.LanguageContext;
         }
     }
 

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -4265,6 +4265,7 @@ namespace IronPython.Runtime
     }
 
     public static class PythonContextHelpers {
+        [Obsolete("Use context.LanguageContext instead")]
         public static PythonContext GetPythonContext(this CodeContext context) {
             return context.LanguageContext;
         }

--- a/Src/IronPython/Runtime/PythonDictionary.cs
+++ b/Src/IronPython/Runtime/PythonDictionary.cs
@@ -457,7 +457,7 @@ namespace IronPython.Runtime {
                 }
             } else {
                 // slow path, cls.__new__ returned a user defined dictionary instead of a PythonDictionary.
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
                 IEnumerator i = PythonOps.GetEnumerator(o);
                 while (i.MoveNext()) {
                     pc.SetIndex(dict, i.Current, value);
@@ -477,7 +477,7 @@ namespace IronPython.Runtime {
             XRange xr = seq as XRange;
             if (xr != null) {
                 int n = xr.__len__();
-                object ret = PythonContext.GetContext(context).CallSplat(cls);
+                object ret = context.LanguageContext.CallSplat(cls);
                 if (ret.GetType() == typeof(PythonDictionary)) {
                     PythonDictionary dr = ret as PythonDictionary;
                     for (int i = 0; i < n; i++) {
@@ -485,7 +485,7 @@ namespace IronPython.Runtime {
                     }
                 } else {
                     // slow path, user defined dict
-                    PythonContext pc = PythonContext.GetContext(context);
+                    PythonContext pc = context.LanguageContext;
                     for (int i = 0; i < n; i++) {
                         pc.SetIndex(ret, xr[i], value);
                     }
@@ -512,7 +512,7 @@ namespace IronPython.Runtime {
                 return NotImplementedType.Value;
 
             return ScriptingRuntimeHelpers.BooleanToObject(
-                ((IStructuralEquatable)this).Equals(other, PythonContext.GetContext(context).EqualityComparerNonGeneric)
+                ((IStructuralEquatable)this).Equals(other, context.LanguageContext.EqualityComparerNonGeneric)
             );
         }
 
@@ -522,7 +522,7 @@ namespace IronPython.Runtime {
                 return NotImplementedType.Value;
 
             return ScriptingRuntimeHelpers.BooleanToObject(
-                !((IStructuralEquatable)this).Equals(other, PythonContext.GetContext(context).EqualityComparerNonGeneric)
+                !((IStructuralEquatable)this).Equals(other, context.LanguageContext.EqualityComparerNonGeneric)
             );
         }
 
@@ -539,7 +539,7 @@ namespace IronPython.Runtime {
 
                 // user-defined dictionary...
                 int lcnt = Count;
-                int rcnt = PythonContext.GetContext(context).ConvertToInt32(PythonOps.CallWithContext(context, len));
+                int rcnt = context.LanguageContext.ConvertToInt32(PythonOps.CallWithContext(context, len));
 
                 if (lcnt != rcnt) return lcnt > rcnt ? 1 : -1;
 

--- a/Src/IronPython/Runtime/PythonFile.cs
+++ b/Src/IronPython/Runtime/PythonFile.cs
@@ -1072,15 +1072,15 @@ namespace IronPython.Runtime {
         }
 
         public PythonFile(CodeContext/*!*/ context)
-            : this(PythonContext.GetContext(context)) {
+            : this(context.LanguageContext) {
         }
 
         internal static PythonFile/*!*/ Create(CodeContext/*!*/ context, Stream/*!*/ stream, string/*!*/ name, string/*!*/ mode) {
-            return Create(context, stream, PythonContext.GetContext(context).DefaultEncoding, name, mode);
+            return Create(context, stream, context.LanguageContext.DefaultEncoding, name, mode);
         }
 
         internal static PythonFile/*!*/ Create(CodeContext/*!*/ context, Stream/*!*/ stream, Encoding/*!*/ encoding, string/*!*/ name, string/*!*/ mode) {
-            PythonFile res = new PythonFile(PythonContext.GetContext(context));
+            PythonFile res = new PythonFile(context.LanguageContext);
             res.__init__(stream, encoding, name, mode);
             return res;
         }
@@ -1093,7 +1093,7 @@ namespace IronPython.Runtime {
 
 #if FEATURE_NATIVE
         internal static PythonFile[] CreatePipe(CodeContext/*!*/ context) {
-            var pythonContext = PythonContext.GetContext(context);
+            var pythonContext = context.LanguageContext;
             var encoding = pythonContext.DefaultEncoding;
 
             var inPipe = new AnonymousPipeServerStream(PipeDirection.In);
@@ -1110,8 +1110,8 @@ namespace IronPython.Runtime {
         public static PythonTuple CreatePipeAsFd(CodeContext context) {
             var pipeFiles = CreatePipe(context);
             return PythonTuple.MakeTuple(
-                PythonContext.GetContext(context).FileManager.AddToStrongMapping(pipeFiles[0]),
-                PythonContext.GetContext(context).FileManager.AddToStrongMapping(pipeFiles[1]));
+                context.LanguageContext.FileManager.AddToStrongMapping(pipeFiles[0]),
+                context.LanguageContext.FileManager.AddToStrongMapping(pipeFiles[1]));
         }
 #endif
 
@@ -1168,9 +1168,9 @@ namespace IronPython.Runtime {
                     if (Environment.OSVersion.Platform == PlatformID.Win32NT && name == "nul") {
                         stream = Stream.Null;
                     } else if (buffering <= 0) {
-                        stream = PythonContext.GetContext(context).DomainManager.Platform.OpenInputFileStream(name, fmode, faccess, fshare);
+                        stream = context.LanguageContext.DomainManager.Platform.OpenInputFileStream(name, fmode, faccess, fshare);
                     } else {
-                        stream = PythonContext.GetContext(context).DomainManager.Platform.OpenInputFileStream(name, fmode, faccess, fshare, buffering);
+                        stream = context.LanguageContext.DomainManager.Platform.OpenInputFileStream(name, fmode, faccess, fshare, buffering);
                     }
                 } catch (IOException e) {
                     AddFilename(context, name, e);
@@ -1182,7 +1182,7 @@ namespace IronPython.Runtime {
 
                 if (seekEnd) stream.Seek(0, SeekOrigin.End);
 
-                __init__(stream, PythonContext.GetContext(context).DefaultEncoding, name, mode);
+                __init__(stream, context.LanguageContext.DefaultEncoding, name, mode);
                 this._isOpen = true;
             } catch (UnauthorizedAccessException e) {
                 throw ToIoException(context, name, e);
@@ -1271,11 +1271,11 @@ namespace IronPython.Runtime {
             else if (stream.CanWrite) mode = "w";
             else mode = "r";
 
-            __init__(stream, PythonContext.GetContext(context).DefaultEncoding, mode);
+            __init__(stream, context.LanguageContext.DefaultEncoding, mode);
         }
 
         public void __init__(CodeContext/*!*/ context, [NotNull]Stream/*!*/ stream, string mode) {
-            __init__(stream, PythonContext.GetContext(context).DefaultEncoding, mode);
+            __init__(stream, context.LanguageContext.DefaultEncoding, mode);
         }
 
         public void __init__([NotNull]Stream/*!*/ stream, Encoding encoding, string mode) {

--- a/Src/IronPython/Runtime/StringFormatter.cs
+++ b/Src/IronPython/Runtime/StringFormatter.cs
@@ -258,7 +258,7 @@ namespace IronPython.Runtime {
             if (_curCh == '*') {
                 if (!(_data is PythonTuple)) { throw PythonOps.TypeError("* requires a tuple for values"); }
                 _curCh = _str[_index++];
-                res = PythonContext.GetContext(_context).ConvertToInt32(GetData(_dataIndex++));
+                res = _context.LanguageContext.ConvertToInt32(GetData(_dataIndex++));
             } else {
                 if (Char.IsDigit(_curCh)) {
                     res = 0;
@@ -387,7 +387,7 @@ namespace IronPython.Runtime {
             object val;
             int intVal;
 
-            if (PythonContext.GetContext(_context).TryConvertToInt32(_opts.Value, out intVal)) {
+            if (_context.LanguageContext.TryConvertToInt32(_opts.Value, out intVal)) {
                 val = intVal;
                 fPos = intVal >= 0;
             } else {

--- a/Src/IronPython/Runtime/Types/BuiltinFunction.cs
+++ b/Src/IronPython/Runtime/Types/BuiltinFunction.cs
@@ -165,11 +165,11 @@ namespace IronPython.Runtime.Types {
 
         private static SiteLocalStorage<CallSite<Func<CallSite, CodeContext, object, object[], object>>> GetInitializedStorage(CodeContext context, SiteLocalStorage<CallSite<Func<CallSite, CodeContext, object, object[], object>>> storage) {
             if (storage == null) {
-                storage = PythonContext.GetContext(context).GetGenericCallSiteStorage();
+                storage = context.LanguageContext.GetGenericCallSiteStorage();
             }
 
             if (storage.Data == null) {
-                storage.Data = PythonContext.GetContext(context).MakeSplatSite();
+                storage.Data = context.LanguageContext.MakeSplatSite();
             }
             return storage;
         }
@@ -177,7 +177,7 @@ namespace IronPython.Runtime.Types {
         private static SiteLocalStorage<CallSite<Func<CallSite, CodeContext, object, object>>> GetInitializedStorage(CodeContext context, SiteLocalStorage<CallSite<Func<CallSite, CodeContext, object, object>>> storage) {
             if (storage.Data == null) {
                 storage.Data = CallSite<Func<CallSite, CodeContext, object, object>>.Create(
-                    PythonContext.GetContext(context).InvokeNone
+                    context.LanguageContext.InvokeNone
                 );
             }
             return storage;
@@ -185,11 +185,11 @@ namespace IronPython.Runtime.Types {
 
         internal object Call(CodeContext context, SiteLocalStorage<CallSite<Func<CallSite, CodeContext, object, object[], IDictionary<object, object>, object>>> storage, object instance, object[] args, IDictionary<object, object> keywordArgs) {
             if (storage == null) {
-                storage = PythonContext.GetContext(context).GetGenericKeywordCallSiteStorage();
+                storage = context.LanguageContext.GetGenericKeywordCallSiteStorage();
             }
 
             if (storage.Data == null) {
-                storage.Data = PythonContext.GetContext(context).MakeKeywordSplatSite();
+                storage.Data = context.LanguageContext.MakeKeywordSplatSite();
             }
 
             if (instance != null) {

--- a/Src/IronPython/Runtime/Types/InstanceCreator.cs
+++ b/Src/IronPython/Runtime/Types/InstanceCreator.cs
@@ -75,7 +75,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _ctorSite0,
                     CallSite<Func<CallSite, CodeContext, BuiltinFunction, PythonType, object>>.Create(
-                        PythonContext.GetContext(context).InvokeOne
+                        context.LanguageContext.InvokeOne
                     ),
                     null
                 );
@@ -89,7 +89,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _ctorSite1,
                     CallSite<Func<CallSite, CodeContext, BuiltinFunction, PythonType, object, object>>.Create(
-                        PythonContext.GetContext(context).Invoke(
+                        context.LanguageContext.Invoke(
                             new CallSignature(2)
                         )
                     ),
@@ -105,7 +105,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _ctorSite2,
                     CallSite<Func<CallSite, CodeContext, BuiltinFunction, PythonType, object, object, object>>.Create(
-                        PythonContext.GetContext(context).Invoke(
+                        context.LanguageContext.Invoke(
                             new CallSignature(3)
                         )
                     ),
@@ -121,7 +121,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _ctorSite3,
                     CallSite<Func<CallSite, CodeContext, BuiltinFunction, PythonType, object, object, object, object>>.Create(
-                        PythonContext.GetContext(context).Invoke(
+                        context.LanguageContext.Invoke(
                             new CallSignature(4)
                         )
                     ),
@@ -137,7 +137,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _ctorSite,
                     CallSite<Func<CallSite, CodeContext, BuiltinFunction, PythonType, object[], object>>.Create(
-                        PythonContext.GetContext(context).Invoke(
+                        context.LanguageContext.Invoke(
                             new CallSignature(
                                 new Argument(ArgumentType.Simple),
                                 new Argument(ArgumentType.List)
@@ -172,7 +172,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _ctorSite0,
                     CallSite<Func<CallSite, CodeContext, BuiltinFunction, object>>.Create(
-                        PythonContext.GetContext(context).InvokeNone
+                        context.LanguageContext.InvokeNone
                     ),
                     null
                 );
@@ -186,7 +186,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _ctorSite1,
                     CallSite<Func<CallSite, CodeContext, BuiltinFunction, object, object>>.Create(
-                        PythonContext.GetContext(context).Invoke(
+                        context.LanguageContext.Invoke(
                             new CallSignature(1)
                         )
                     ),
@@ -202,7 +202,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _ctorSite2,
                     CallSite<Func<CallSite, CodeContext, BuiltinFunction, object, object, object>>.Create(
-                        PythonContext.GetContext(context).Invoke(
+                        context.LanguageContext.Invoke(
                             new CallSignature(2)
                         )
                     ),
@@ -218,7 +218,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _ctorSite3,
                     CallSite<Func<CallSite, CodeContext, BuiltinFunction, object, object, object, object>>.Create(
-                        PythonContext.GetContext(context).Invoke(
+                        context.LanguageContext.Invoke(
                             new CallSignature(3)
                         )
                     ),
@@ -234,7 +234,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _ctorSite,
                     CallSite<Func<CallSite, CodeContext, BuiltinFunction, object[], object>>.Create(
-                        PythonContext.GetContext(context).Invoke(
+                        context.LanguageContext.Invoke(
                             new CallSignature(
                                 new Argument(ArgumentType.List)
                             )

--- a/Src/IronPython/Runtime/Types/OldInstance.cs
+++ b/Src/IronPython/Runtime/Types/OldInstance.cs
@@ -353,7 +353,7 @@ namespace IronPython.Runtime.Types {
         [SpecialName]
         public object Call(CodeContext context, object args) {
             try {
-                PythonOps.FunctionPushFrame(PythonContext.GetContext(context));
+                PythonOps.FunctionPushFrame(context.LanguageContext);
 
                 object value;
                 if (TryGetBoundCustomMember(context, "__call__", out value)) {
@@ -369,7 +369,7 @@ namespace IronPython.Runtime.Types {
         [SpecialName]
         public object Call(CodeContext context, params object[] args) {
             try {
-                PythonOps.FunctionPushFrame(PythonContext.GetContext(context));
+                PythonOps.FunctionPushFrame(context.LanguageContext);
 
                 object value;
                 if (TryGetBoundCustomMember(context, "__call__", out value)) {
@@ -385,7 +385,7 @@ namespace IronPython.Runtime.Types {
         [SpecialName]
         public object Call(CodeContext context, [ParamDictionary]IDictionary<object, object> dict, params object[] args) {
             try {
-                PythonOps.FunctionPushFrame(PythonContext.GetContext(context));
+                PythonOps.FunctionPushFrame(context.LanguageContext);
 
                 object value;
                 if (TryGetBoundCustomMember(context, "__call__", out value)) {

--- a/Src/IronPython/Runtime/Types/PythonSiteCache.cs
+++ b/Src/IronPython/Runtime/Types/PythonSiteCache.cs
@@ -52,7 +52,7 @@ namespace IronPython.Runtime.Types {
                 lock (_tryGetMemSiteShowCls) {
                     if (!_tryGetMemSiteShowCls.TryGetValue(name, out site)) {
                         _tryGetMemSiteShowCls[name] = site = CallSite<Func<CallSite, object, CodeContext, object>>.Create(
-                            PythonContext.GetContext(context).GetMember(
+                            context.LanguageContext.GetMember(
                                 name,
                                 true
                             )
@@ -71,7 +71,7 @@ namespace IronPython.Runtime.Types {
                 lock (_tryGetMemSite) {
                     if (!_tryGetMemSite.TryGetValue(name, out site)) {
                         _tryGetMemSite[name] = site = CallSite<Func<CallSite, object, CodeContext, object>>.Create(
-                            PythonContext.GetContext(context).GetMember(
+                            context.LanguageContext.GetMember(
                                 name,
                                 true
                             )
@@ -87,7 +87,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _dirSite,
                     CallSite<Func<CallSite, CodeContext, object, object>>.Create(
-                        PythonContext.GetContext(context).InvokeNone
+                        context.LanguageContext.InvokeNone
                     ),
                     null);
             }
@@ -99,7 +99,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _getAttributeSite,
                     CallSite<Func<CallSite, CodeContext, object, string, object>>.Create(
-                        PythonContext.GetContext(context).InvokeOne
+                        context.LanguageContext.InvokeOne
                     ),
                     null
                 );
@@ -112,7 +112,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _setAttrSite,
                     CallSite<Func<CallSite, CodeContext, object, object, string, object, object>>.Create(
-                        PythonContext.GetContext(context).Invoke(
+                        context.LanguageContext.Invoke(
                             new CallSignature(4)
                         )
                     ),
@@ -127,7 +127,7 @@ namespace IronPython.Runtime.Types {
                 Interlocked.CompareExchange(
                     ref _lenSite,
                     CallSite<Func<CallSite, CodeContext, object, object>>.Create(
-                        PythonContext.GetContext(context).InvokeNone
+                        context.LanguageContext.InvokeNone
                     ),
                     null
                 );

--- a/Src/IronPython/Runtime/Types/PythonType.cs
+++ b/Src/IronPython/Runtime/Types/PythonType.cs
@@ -761,7 +761,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             IList<WeakReference> subtypes = SubTypes;
 
             if (subtypes != null) {
-                PythonContext pc = PythonContext.GetContext(context);
+                PythonContext pc = context.LanguageContext;
 
                 foreach (WeakReference wr in subtypes) {
                     if (wr.IsAlive) {
@@ -999,7 +999,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         internal bool TryGetLength(CodeContext context, object o, out int length) {
             CallSite<Func<CallSite, CodeContext, object, object>> lenSite;
             if (IsSystemType) {
-                lenSite = PythonContext.GetContext(context).GetSiteCacheForSystemType(UnderlyingSystemType).GetLenSite(context);
+                lenSite = context.LanguageContext.GetSiteCacheForSystemType(UnderlyingSystemType).GetLenSite(context);
             } else {
                 lenSite = _siteCache.GetLenSite(context);
             }
@@ -1052,7 +1052,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         internal bool TryGetBoundAttr(CodeContext context, object o, string name, out object ret) {
             CallSite<Func<CallSite, object, CodeContext, object>> site;
             if (IsSystemType) {
-                site = PythonContext.GetContext(context).GetSiteCacheForSystemType(UnderlyingSystemType).GetTryGetMemberSite(context, name);
+                site = context.LanguageContext.GetSiteCacheForSystemType(UnderlyingSystemType).GetTryGetMemberSite(context, name);
             } else {
                 site = _siteCache.GetTryGetMemberSite(context, name);
             }
@@ -1445,7 +1445,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         }
 
         internal bool TryGetCustomSetAttr(CodeContext context, out PythonTypeSlot pts) {
-            PythonContext pc = PythonContext.GetContext(context);
+            PythonContext pc = context.LanguageContext;
             return pc.Binder.TryResolveSlot(
                     context,
                     DynamicHelpers.GetPythonType(this),
@@ -1685,7 +1685,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         private object InvokeGetAttributeMethod(CodeContext context, string name, object getattr) {
             CallSite<Func<CallSite, CodeContext, object, string, object>> getAttributeSite;
             if (IsSystemType) {
-                getAttributeSite = PythonContext.GetContext(context).GetSiteCacheForSystemType(UnderlyingSystemType).GetGetAttributeSite(context);
+                getAttributeSite = context.LanguageContext.GetSiteCacheForSystemType(UnderlyingSystemType).GetGetAttributeSite(context);
             } else {
                 getAttributeSite = _siteCache.GetGetAttributeSite(context);
             }
@@ -1767,7 +1767,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
             if (TryResolveNonObjectSlot(context, instance, "__setattr__", out setattr)) {
                 CallSite<Func<CallSite, CodeContext, object, object, string, object, object>> setAttrSite;
                 if (IsSystemType) {
-                    setAttrSite = PythonContext.GetContext(context).GetSiteCacheForSystemType(UnderlyingSystemType).GetSetAttrSite(context);
+                    setAttrSite = context.LanguageContext.GetSiteCacheForSystemType(UnderlyingSystemType).GetSetAttrSite(context);
                 } else {
                     setAttrSite = _siteCache.GetSetAttrSite(context);
                 }
@@ -1905,7 +1905,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                 if (TryResolveNonObjectSlot(context, self, "__dir__", out dir)) {
                     CallSite<Func<CallSite, CodeContext, object, object>> dirSite;
                     if (IsSystemType) {
-                        dirSite = PythonContext.GetContext(context).GetSiteCacheForSystemType(UnderlyingSystemType).GetDirSite(context);
+                        dirSite = context.LanguageContext.GetSiteCacheForSystemType(UnderlyingSystemType).GetDirSite(context);
                     } else {
                         dirSite = _siteCache.GetDirSite(context);
                     }
@@ -2011,7 +2011,7 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
 
             _name = name;
             _bases = GetBasesAsList(bases).ToArray();
-            _pythonContext = PythonContext.GetContext(context);
+            _pythonContext = context.LanguageContext;
             _resolutionOrder = CalculateMro(this, _bases);
 
             bool hasSlots = false;
@@ -3229,12 +3229,12 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
         private object GetAttr(CodeContext context, object res) {
             if (_isNoThrow) {
                 try {
-                    return PythonContext.GetContext(context).Call(context, res, _name);
+                    return context.LanguageContext.Call(context, res, _name);
                 } catch (MissingMemberException) {
                     return OperationFailed.Value;
                 }
             } else {
-                return PythonContext.GetContext(context).Call(context, res, _name);
+                return context.LanguageContext.Call(context, res, _name);
             }
         }
 

--- a/Src/IronPython/Runtime/Types/PythonTypeUserDescriptorSlot.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeUserDescriptorSlot.cs
@@ -60,7 +60,7 @@ namespace IronPython.Runtime.Types {
             object res;
             Debug.Assert(_desc.GetAlwaysSucceeds);
             _desc.TryGetValue(context, _value, DynamicHelpers.GetPythonType(_value), out res);
-            return PythonContext.GetContext(context).Call(context, res, instance, owner);
+            return context.LanguageContext.Call(context, res, instance, owner);
         }
 
         private void CalculateDescriptorInfo() {

--- a/Src/IronPython/Runtime/Types/PythonTypeWeakRefSlot.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeWeakRefSlot.cs
@@ -33,7 +33,7 @@ namespace IronPython.Runtime.Types {
             }
 
             IWeakReferenceable reference;
-            if (context.GetPythonContext().TryConvertToWeakReferenceable(instance, out reference)) {
+            if (context.LanguageContext.TryConvertToWeakReferenceable(instance, out reference)) {
                 WeakRefTracker tracker = reference.GetWeakRef();
                 if (tracker == null || tracker.HandlerCount == 0) {
                     value = null;
@@ -49,7 +49,7 @@ namespace IronPython.Runtime.Types {
 
         internal override bool TrySetValue(CodeContext context, object instance, PythonType owner, object value) {
             IWeakReferenceable reference;
-            if (context.GetPythonContext().TryConvertToWeakReferenceable(instance, out reference)) {
+            if (context.LanguageContext.TryConvertToWeakReferenceable(instance, out reference)) {
                 return reference.SetWeakRef(new WeakRefTracker(reference, value, instance));
             }
             return false;

--- a/Src/IronPython/Runtime/Types/ReflectedEvent.cs
+++ b/Src/IronPython/Runtime/Types/ReflectedEvent.cs
@@ -210,7 +210,7 @@ namespace IronPython.Runtime.Types {
                 if (CompilerHelpers.IsVisible(remove)
                     || (remove.IsProtected() /*todo: validate current context is in family*/ )
                     || context.LanguageContext.DomainManager.Configuration.PrivateBinding) {
-                    _event.Tracker.RemoveHandler(_instance, func, PythonContext.GetContext(context).EqualityComparer);
+                    _event.Tracker.RemoveHandler(_instance, func, context.LanguageContext.EqualityComparer);
                 } else {
                     throw new TypeErrorException("Cannot remove handler from a private event.");
                 }

--- a/Src/IronPython/Runtime/Types/ReflectedProperty.cs
+++ b/Src/IronPython/Runtime/Types/ReflectedProperty.cs
@@ -84,7 +84,7 @@ namespace IronPython.Runtime.Types {
                 }
             }
 
-            return CallSetter(context, PythonContext.GetContext(context).GetGenericCallSiteStorage(), instance, ArrayUtils.EmptyObjects, value);
+            return CallSetter(context, context.LanguageContext.GetGenericCallSiteStorage(), instance, ArrayUtils.EmptyObjects, value);
         }
 
         internal override Type DeclaringType {
@@ -112,7 +112,7 @@ namespace IronPython.Runtime.Types {
         internal override bool TryGetValue(CodeContext context, object instance, PythonType owner, out object value) {
             PerfTrack.NoteEvent(PerfTrack.Categories.Properties, this);
 
-            value = CallGetter(context, owner, PythonContext.GetContext(context).GetGenericCallSiteStorage0(), instance);
+            value = CallGetter(context, owner, context.LanguageContext.GetGenericCallSiteStorage0(), instance);
             return true;
         }
 

--- a/Src/IronPython/Runtime/WeakRef.cs
+++ b/Src/IronPython/Runtime/WeakRef.cs
@@ -181,7 +181,7 @@ namespace IronPython.Runtime {
             IronPython.Runtime.Types.OldInstance oi = _instance as IronPython.Runtime.Types.OldInstance;
             if (oi != null) {
                 if (oi.TryGetBoundCustomMember(context, "__del__", out o)) {
-                    return PythonContext.GetContext(context).CallSplat(o);
+                    return context.LanguageContext.CallSplat(o);
                 }
             } else {
                 PythonTypeOps.TryInvokeUnaryOperator(context, _instance, "__del__", out o);


### PR DESCRIPTION
Removes redundant `PythonContext.GetContext` and `PythonContext.GetPythonContext` APIs. Note that since PythonContext.GetPythonContext was a public API I made it obsolete instead of removing it.