### PR TITLE
Make it so that Arguments is full arguments

### DIFF
--- a/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/AllCPythonCasesManifest.ini
@@ -1,6 +1,7 @@
 ﻿[DEFAULT]
 Ignore=false
-WorkingDirectory=${ROOT}/Src/StdLib/Lib
+Arguments="$(TEST_FILE)"
+WorkingDirectory=$(ROOT)/Src/StdLib/Lib
 
 [test___all__]
 Ignore=true
@@ -518,6 +519,7 @@ Ignore=true
 Condition='$(OS)' != 'Unix'
 Reason=Currently failing on Unix because we do not implement some posix things
 IsolationLevel=PROCESS
+Arguments=-m test.regrtest -v -uall,-largefile test_mmap
 
 [test_modulefinder]
 Ignore=true

--- a/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/IronPythonCasesManifest.ini
@@ -1,7 +1,8 @@
 ﻿[DEFAULT]
 Ignore=false
+Arguments="$(TEST_FILE)"
 IsolationLevel=PROCESS
-WorkingDirectory=${ROOT}/Tests
+WorkingDirectory=$(ROOT)/Tests
 
 [test_cliclass]
 Condition='$(OS)' != 'Unix'
@@ -63,7 +64,7 @@ Ignore=true
 Reason=Uses MAUI framework, which was MS internal?
 
 [test_sys_getframe]
-Arguments=-X:FullFrames
+Arguments=-X:FullFrames "$(TEST_FILE)"
 
 [test_traceback]
 Ignore=true

--- a/Src/IronPythonTest/Cases/StandardCPythonCasesManifest.ini
+++ b/Src/IronPythonTest/Cases/StandardCPythonCasesManifest.ini
@@ -1,6 +1,6 @@
 ﻿[DEFAULT]
 Ignore=false
-WorkingDirectory=${ROOT}/Src/StdLib/Lib
+WorkingDirectory=$(ROOT)/Src/StdLib/Lib
 
 [test___all__]
 Ignore=true


### PR DESCRIPTION
This allows us to specify the full set of args to ipy.exe when running tests.