### PR TITLE
Fix #4

### DIFF
--- a/Src/IronPython.Modules/socket.cs
+++ b/Src/IronPython.Modules/socket.cs
@@ -2865,7 +2865,7 @@ namespace IronPython.Modules {
             [Documentation(@"read([len]) -> string
 
 Read up to len bytes from the SSL socket.")]
-            public string read(CodeContext/*!*/ context, [DefaultParameterValue(Int32.MaxValue)] int len) {
+            public string read(CodeContext/*!*/ context, int len) {
                 EnsureSslStream(true);
 
                 try {


### PR DESCRIPTION
Looks like the `len` argument is not actually optional even though the doc string seems to say it is.