### PR TITLE
Avoid StackOverflowException in mimetypes

### DIFF
--- a/Src/StdLib/Lib/mimetypes.py
+++ b/Src/StdLib/Lib/mimetypes.py
@@ -253,23 +253,25 @@ class MimeTypes:
         default_encoding = sys.getdefaultencoding()
         with _winreg.OpenKey(_winreg.HKEY_CLASSES_ROOT, '') as hkcr:
             for subkeyname in enum_types(hkcr):
-                try:
-                    with _winreg.OpenKey(hkcr, subkeyname) as subkey:
-                        # Only check file extensions
-                        if not subkeyname.startswith("."):
-                            continue
+                with _winreg.OpenKey(hkcr, subkeyname) as subkey:
+                    # Only check file extensions
+                    if not subkeyname.startswith("."):
+                        continue
+                    try:
                         # raises EnvironmentError if no 'Content Type' value
                         mimetype, datatype = _winreg.QueryValueEx(
                             subkey, 'Content Type')
+                    except EnvironmentError:
+                        pass
+                    else:
                         if datatype != _winreg.REG_SZ:
                             continue
                         try:
                             mimetype = mimetype.encode(default_encoding)
                         except UnicodeEncodeError:
-                            continue
-                        self.add_type(mimetype, subkeyname, strict)
-                except EnvironmentError:
-                    continue
+                            pass
+                        else:
+                            self.add_type(mimetype, subkeyname, strict)
 
 def guess_type(url, strict=True):
     """Guess the type of a file based on its URL.


### PR DESCRIPTION
Rewrites the loop in mimetypes to try and avoid the StackOverflowException (IronLanguages/ironpython2#40). This should be reverted once the underlying issue is fixed.