### PR TITLE
 Remove condition on TargetFrameworks and update NuGet packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 MSBUILD := msbuild
+CONSOLERUNNER := ../../../packages/nunit.consolerunner/3.7.0/tools/nunit3-console.exe
 
 .PHONY: debug release test stage package clean test-smoke test-smoke-debug test-ironpython test-ironpython-debug test-cpython test-cpython-debug test-all test-all-debug
 
@@ -23,25 +24,25 @@ update-submodules:
 	@git submodule update --init
 
 test-ironpython:
-	cd bin/Release/net45 && mono ../../../packages/nunit.consolerunner/3.6.1/tools/nunit3-console.exe --labels=All --where:Category==IronPython --result:ironpython-net45-release-result.xml IronPythonTest.dll
+	cd bin/Release/net45 && mono $(CONSOLERUNNER) --labels=All --where:Category==IronPython --result:ironpython-net45-release-result.xml IronPythonTest.dll
 
 test-ironpython-debug:
-	cd bin/Debug/net45 && mono ../../../packages/nunit.consolerunner/3.6.1/tools/nunit3-console.exe --labels=All --where:Category==IronPython --result:ironpython-net45-debug-result.xml IronPythonTest.dll
+	cd bin/Debug/net45 && mono $(CONSOLERUNNER) --labels=All --where:Category==IronPython --result:ironpython-net45-debug-result.xml IronPythonTest.dll
 
 test-cpython:
-	cd bin/Release/net45 && mono ../../../packages/nunit.consolerunner/3.6.1/tools/nunit3-console.exe --labels=All --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-net45-release-result.xml IronPythonTest.dll
+	cd bin/Release/net45 && mono $(CONSOLERUNNER) --labels=All --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-net45-release-result.xml IronPythonTest.dll
 
 test-cpython-debug:
-	cd bin/Debug/net45 && mono ../../../packages/nunit.consolerunner/3.6.1/tools/nunit3-console.exe --labels=All --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-net45-debug-result.xml IronPythonTest.dll
+	cd bin/Debug/net45 && mono $(CONSOLERUNNER) --labels=All --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-net45-debug-result.xml IronPythonTest.dll
 
 test-smoke:
-	cd bin/Release/net45 && mono ../../../packages/nunit.consolerunner/3.6.1/tools/nunit3-console.exe --labels=All --where:Category==StandardCPython --result=smoke-net45-release-result.xml IronPythonTest.dll
+	cd bin/Release/net45 && mono $(CONSOLERUNNER) --labels=All --where:Category==StandardCPython --result=smoke-net45-release-result.xml IronPythonTest.dll
 
 test-smoke-debug:
-	cd bin/Debug/net45 && mono ../../../packages/nunit.consolerunner/3.6.1/tools/nunit3-console.exe --labels=All --where:Category==StandardCPython --result=smoke-net45-debug-result.xml IronPythonTest.dll
+	cd bin/Debug/net45 && mono $(CONSOLERUNNER) --labels=All --where:Category==StandardCPython --result=smoke-net45-debug-result.xml IronPythonTest.dll
 
 test-all:
-	cd bin/Release/net45 && mono ../../../packages/nunit.consolerunner/3.6.1/tools/nunit3-console.exe --labels=All --result=all-net45-release-result.xml IronPythonTest.dll
+	cd bin/Release/net45 && mono $(CONSOLERUNNER) --labels=All --result=all-net45-release-result.xml IronPythonTest.dll
 
 test-all-debug:
-	cd bin/Debugnet45 && mono ../../../packages/nunit.consolerunner/3.6.1/tools/nunit3-console.exe --labels=All --result=all-net45-debug-result.xml IronPythonTest.dll
+	cd bin/Debugnet45 && mono $(CONSOLERUNNER) --labels=All --result=all-net45-debug-result.xml IronPythonTest.dll

--- a/Src/IronPython.Modules/IronPython.Modules.csproj
+++ b/Src/IronPython.Modules/IronPython.Modules.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(ProjectDir)..\..\Build\Common.proj" />
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net40;net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netcoreapp2.0</TargetFrameworks>
     <PlatformTarget>anycpu</PlatformTarget>
     <ProjectGuid>{155CE436-1669-4A48-8095-410F2430237F}</ProjectGuid>
     <OutputType>Library</OutputType>

--- a/Src/IronPython.SQLite/IronPython.SQLite.csproj
+++ b/Src/IronPython.SQLite/IronPython.SQLite.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(ProjectDir)..\..\Build\Common.proj" />
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net40;net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netcoreapp2.0</TargetFrameworks>
     <PlatformTarget>anycpu</PlatformTarget>
     <ProjectGuid>{4A617A40-2BA7-4713-AAFE-F90C4325C581}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IronPython.SQLite</RootNamespace>
     <AssemblyName>IronPython.SQLite</AssemblyName>
-    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
+    <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <SQLiteCommon>SQLITE_DEBUG;TRUE;WIN32;_MSC_VER;SQLITE_ASCII;SQLITE_MEM_POOL;SQLITE_ENABLE_COLUMN_METADATA;SQLITE_OS_WIN;SQLITE_SYSTEM_MALLOC;VDBE_PROFILE_OFF</SQLiteCommon>
     <SQLiteCommonOmit>SQLITE_OMIT_AUTHORIZATION;SQLITE_OMIT_DEPRECATED;SQLITE_OMIT_GET_TABLE;SQLITE_OMIT_INCRBLOB;SQLITE_OMIT_LOOKASIDE;SQLITE_OMIT_SHARED_CACHE;SQLITE_OMIT_UTF16;SQLITE_OMIT_WAL</SQLiteCommonOmit>
     <NoWarn>$(NoWarn);0168;0169;0414;0618;0649;1587;219;1570</NoWarn>

--- a/Src/IronPython.Wpf/IronPython.Wpf.csproj
+++ b/Src/IronPython.Wpf/IronPython.Wpf.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IronPython.Wpf</RootNamespace>
     <AssemblyName>IronPython.Wpf</AssemblyName>
-    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
+    <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <BaseAddress>885063680</BaseAddress>
     <StoreInDLLs>true</StoreInDLLs>
   </PropertyGroup>

--- a/Src/IronPython/IronPython.csproj
+++ b/Src/IronPython/IronPython.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(ProjectDir)..\..\Build\Common.proj" />
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net40;net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netcoreapp2.0</TargetFrameworks>
     <PlatformTarget>anycpu</PlatformTarget>
     <ProjectGuid>{95289EA9-5778-489D-AB48-F81F2CE2DA32}</ProjectGuid>
     <OutputType>Library</OutputType>

--- a/Src/IronPythonConsoleAny/IronPythonConsoleAny.csproj
+++ b/Src/IronPythonConsoleAny/IronPythonConsoleAny.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(ProjectDir)..\..\Build\Common.proj" />
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net40;net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netcoreapp2.0</TargetFrameworks>
     <PlatformTarget>anycpu</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
     <ProjectGuid>{F1D861C5-D9D5-4CDA-968B-8275F5D9F6D2}</ProjectGuid>

--- a/Src/IronPythonTest/IronPythonTest.csproj
+++ b/Src/IronPythonTest/IronPythonTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(ProjectDir)..\..\Build\Common.proj" />
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">net40;net45;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netcoreapp2.0</TargetFrameworks>
     <PlatformTarget>anycpu</PlatformTarget>
     <PlatformTarget Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">x64</PlatformTarget>
     <ProjectGuid>{B6B42537-07F8-4F6C-A99A-B155CAEB124E}</ProjectGuid>

--- a/Src/IronPythonTest/IronPythonTest.csproj
+++ b/Src/IronPythonTest/IronPythonTest.csproj
@@ -17,12 +17,11 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.6.1" />
-    <PackageReference Include="NUnitLite" Version="3.7.2" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.7.0" />
+    <PackageReference Include="NUnitLite" Version="3.8.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
   </ItemGroup>

--- a/make.cmd
+++ b/make.cmd
@@ -134,7 +134,8 @@ for %%f in ("%FRAMEWORKS:,=" "%") do (
   pushd bin\Debug\%%f
   ..\..\..\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe  --labels=All --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-%%f-debug-result.xml IronPythonTest.dll
   popd
-)goto :exit
+)
+goto :exit
 
 :test-all
 for %%f in ("%FRAMEWORKS:,=" "%") do (
@@ -173,7 +174,6 @@ goto :exit
 FOR /F "delims=" %%F IN ("bin\Release\netcoreapp2.0") DO SET "BinDir=%%~fF"
 dotnet test .\Src\IronPythonTest\IronPythonTest.csproj --framework netcoreapp2.0 -o %BinDir% --configuration Release --no-build
 goto :exit
-
 
 :restore
 set _target=RestoreReferences

--- a/make.cmd
+++ b/make.cmd
@@ -18,6 +18,8 @@ if exist "%_VSINSTPATH%\MSBuild\15.0\Bin\MSBuild.exe" (
 
 set FRAMEWORKS=net45,net40
 
+set CONSOLERUNNER="..\..\..\packages\nunit.consolerunner\3.7.0\tools\nunit3-console.exe"
+
 :getopts
 if "%1"=="" (goto :default) else (goto :%1)
 goto :exit
@@ -92,7 +94,7 @@ goto :exit
 :test-smoke
 for %%f in ("%FRAMEWORKS:,=" "%") do (
   pushd bin\Release\%%f
-  ..\..\..\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe  --labels=All --where:"Category==StandardCPython" --result:smoke-%%f-release-result.xml IronPythonTest.dll
+  %CONSOLERUNNER% --labels=All --where:"Category==StandardCPython" --result:smoke-%%f-release-result.xml IronPythonTest.dll
   popd
 )
 goto :exit
@@ -100,7 +102,7 @@ goto :exit
 :test-smoke-debug
 for %%f in ("%FRAMEWORKS:,=" "%") do (
   pushd bin\Debug\%%f
-  ..\..\..\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe  --labels=All --where:"Category==StandardCPython" --result:smoke-%%f-debug-result.xml IronPythonTest.dll
+  %CONSOLERUNNER% --labels=All --where:"Category==StandardCPython" --result:smoke-%%f-debug-result.xml IronPythonTest.dll
   popd
 )
 goto :exit
@@ -108,7 +110,7 @@ goto :exit
 :test-ironpython
 for %%f in ("%FRAMEWORKS:,=" "%") do (
   pushd bin\Release\%%f
-  ..\..\..\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe  --labels=All --where:"Category==IronPython" --result:ironpython-%%f-release-result.xml IronPythonTest.dll
+  %CONSOLERUNNER% --labels=All --where:"Category==IronPython" --result:ironpython-%%f-release-result.xml IronPythonTest.dll
   popd
 )
 goto :exit
@@ -116,7 +118,7 @@ goto :exit
 :test-ironpython-debug
 for %%f in ("%FRAMEWORKS:,=" "%") do (
   pushd bin\Debug\%%f
-  ..\..\..\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe  --labels=All --where:"Category==IronPython" --result:ironpython-%%f-debug-result.xml IronPythonTest.dll
+  %CONSOLERUNNER% --labels=All --where:"Category==IronPython" --result:ironpython-%%f-debug-result.xml IronPythonTest.dll
   popd
 )
 goto :exit
@@ -124,7 +126,7 @@ goto :exit
 :test-cpython
 for %%f in ("%FRAMEWORKS:,=" "%") do (
   pushd bin\Release\%%f
-  ..\..\..\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe  --labels=All --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-%%f-release-result.xml IronPythonTest.dll
+  %CONSOLERUNNER% --labels=All --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-%%f-release-result.xml IronPythonTest.dll
   popd
 )
 goto :exit
@@ -132,7 +134,7 @@ goto :exit
 :test-cpython-debug
 for %%f in ("%FRAMEWORKS:,=" "%") do (
   pushd bin\Debug\%%f
-  ..\..\..\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe  --labels=All --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-%%f-debug-result.xml IronPythonTest.dll
+  %CONSOLERUNNER% --labels=All --where:"Category==StandardCPython || Category==AllCPython" --result:cpython-%%f-debug-result.xml IronPythonTest.dll
   popd
 )
 goto :exit
@@ -140,7 +142,7 @@ goto :exit
 :test-all
 for %%f in ("%FRAMEWORKS:,=" "%") do (
   pushd bin\Release\%%f
-  ..\..\..\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe  --labels=All --result:all-%%f-release-result.xml IronPythonTest.dll
+  %CONSOLERUNNER% --labels=All --result:all-%%f-release-result.xml IronPythonTest.dll
   popd
 )
 goto :exit
@@ -148,7 +150,7 @@ goto :exit
 :test-all-debug
 for %%f in ("%FRAMEWORKS:,=" "%") do (
   pushd bin\Debug\%%f
-  ..\..\..\packages\nunit.consolerunner\3.6.1\tools\nunit3-console.exe  --labels=All --result:all-%%f-debug-result.xml IronPythonTest.dll
+  %CONSOLERUNNER% --labels=All --result:all-%%f-debug-result.xml IronPythonTest.dll
   popd
 )
 goto :exit


### PR DESCRIPTION
Removing the condition prevents VS2017 from trying to trigger a project migration.