### PR TITLE
Remove unused property

### DIFF
--- a/CurrentVersion.props
+++ b/CurrentVersion.props
@@ -9,7 +9,5 @@
     <ReleaseSerial>1</ReleaseSerial>
 
     <AssemblyRevision>0</AssemblyRevision>
-  
-    <DlrVersion>1.2.0-alpha1</DlrVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The DlrVersion property is not used anywhere since we switched to using a submodule instead of nuget.