### PR TITLE
Fix issue with doc builder

### DIFF
--- a/Src/IronPython/Runtime/Types/DocBuilder.cs
+++ b/Src/IronPython/Runtime/Types/DocBuilder.cs
@@ -548,7 +548,10 @@ namespace IronPython.Runtime.Types {
                 // Dynamic assemblies do not support Assembly.Location
             }
 
-            if (location == null) _AssembliesWithoutXmlDoc.Add(assem);
+            if (string.IsNullOrEmpty(location)) {
+                _AssembliesWithoutXmlDoc.Add(assem);
+                return null;
+            }
 
             return location;
         }


### PR DESCRIPTION
On gitter @elitest was running into an issue where code would fail with an `ArgumentException` when the assemblies were packaged using Costura. The failure was because `Assembly.Location` was returning an empty string instead of `null` and the subsequent code did not deal with that case properly.