### PR TITLE
Update ipunittest to match ipy3

### DIFF
--- a/Src/IronPython/Lib/iptest/ipunittest.py
+++ b/Src/IronPython/Lib/iptest/ipunittest.py
@@ -327,7 +327,7 @@ class IronPythonTestCase(unittest.TestCase, FileUtil, ProcessUtil):
 
     # environment variables
     def get_environ_variable(self, key):
-        l = [os.environ[x] for x in os.environ.keys() if x.lower() == key.lower()]
+        l = [y for x, y in os.environ.items() if x.lower() == key.lower()]
         if l: return l[0]
         return None
 


### PR DESCRIPTION
Update to match https://github.com/IronLanguages/ironpython3/commit/68c6ed3a4de6d125433619eec60914438ff99f9d. The reason for the change in ipy3 is failure due to missing yield from implementation.