### PR TITLE
Remove Stack Overflow link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,7 @@ from System.Windows.Forms import *
 
 # Documentation
 
-Documentation can be found here:
-
-1. http://stackoverflow.com/documentation/ironpython/topics
-2. http://ironpython.net/documentation/dotnet/
+Documentation can be found here: http://ironpython.net/documentation/dotnet/
 
 
 ## Additional information


### PR DESCRIPTION
Stack Overflow Documentation was shut down in August 8th, 2017, so the link isn't relevant anymore.