### PR TITLE
Support new style csproj <PackageReference> usage

### DIFF
--- a/Package/nuget/IronPython.StdLib.nuspec
+++ b/Package/nuget/IronPython.StdLib.nuspec
@@ -16,8 +16,11 @@
     <dependencies>
       <dependency id="IronPython" version="[2.7.8,3.0)" />
     </dependencies>
+    <contentFiles>
+      <files include="**\*" buildAction="None" copyToOutput="true" />
+    </contentFiles>
   </metadata>
   <files>
-    <file src="Lib\**" target="content\Lib" />
+    <file src="Lib\**" target="contentFiles\any\any\Lib" />
   </files>
 </package>


### PR DESCRIPTION
Fixes #337 

When including StdLib with <PackageReference /> the Lib folder now shows up in the IDE and gets copied to the output directory.
