### PR TITLE
Unify StringOps and codecs DoDecode methods

### DIFF
--- a/Src/IronPython.Modules/_codecs.cs
+++ b/Src/IronPython.Modules/_codecs.cs
@@ -34,21 +34,10 @@ namespace IronPython.Modules {
         internal const int StreamWriterIndex = 3;
 
         #region ASCII Encoding
-        public static object ascii_decode(object input) {
-            return ascii_decode(input, "strict");
-        }
 
-        public static object ascii_decode(object input, string errors) {
-            return DoDecode(PythonAsciiEncoding.Instance, input, errors, true);
-        }
+        public static object ascii_decode(CodeContext context, object input, string errors = "strict") => DoDecode(context, "ascii", PythonAsciiEncoding.Instance, input, errors, true);
 
-        public static object ascii_encode(object input) {
-            return ascii_encode(input, "strict");
-        }
-
-        public static object ascii_encode(object input, string errors) {
-            return DoEncode(PythonAsciiEncoding.Instance, input, errors);
-        }
+        public static object ascii_encode(object input, string errors = "strict") => DoEncode(PythonAsciiEncoding.Instance, input, errors);
 
         #endregion
 
@@ -94,11 +83,10 @@ namespace IronPython.Modules {
             return CharmapDecodeWorker(context, input, errors, new EncodingMapEncoding(m, errors), true);
         }
 
-        public static PythonTuple charmap_decode(CodeContext context, [BytesConversion]string input, string errors="strict", IDictionary<object, object> map=null) {
+        public static PythonTuple charmap_decode(CodeContext context, [BytesConversion]string input, string errors = "strict", IDictionary<object, object> map = null) {
             Encoding e = map != null ? new CharmapEncoding(map, errors) : null;
             return CharmapDecodeWorker(context, input, errors, e, true);
         }
-
 
         private static PythonTuple CharmapDecodeWorker(CodeContext context, string input, string errors, Encoding e, bool isDecode) {
             if (input.Length == 0) {
@@ -113,12 +101,12 @@ namespace IronPython.Modules {
                 encoding = "latin-1";
             }
 
-            string res = isDecode ? StringOps.DoDecode(context, input, errors, encoding, e) : StringOps.DoEncode(context, input, errors, encoding, e);            
+            string res = isDecode ? StringOps.DoDecode(context, input, errors, encoding, e) : StringOps.DoEncode(context, input, errors, encoding, e);
             return PythonTuple.MakeTuple(res, res.Length);
-        }        
+        }
 
-        public static object decode(CodeContext/*!*/ context, object obj, string encoding=null, string errors="strict") {
-            if(encoding == null) {
+        public static object decode(CodeContext/*!*/ context, object obj, string encoding = null, string errors = "strict") {
+            if (encoding == null) {
                 encoding = context.LanguageContext.DefaultEncoding.EncodingName;
             }
             PythonTuple t = lookup(context, encoding);
@@ -126,7 +114,7 @@ namespace IronPython.Modules {
             return PythonOps.GetIndex(context, PythonCalls.Call(context, t[DecoderIndex], obj, errors), 0);
         }
 
-        public static object encode(CodeContext/*!*/ context, object obj, string encoding=null, string errors="strict") {
+        public static object encode(CodeContext/*!*/ context, object obj, string encoding = null, string errors = "strict") {
             if (encoding == null) {
                 encoding = context.LanguageContext.DefaultEncoding.EncodingName;
             }
@@ -135,7 +123,7 @@ namespace IronPython.Modules {
             return PythonOps.GetIndex(context, PythonCalls.Call(context, t[EncoderIndex], obj, errors), 0);
         }
 
-        public static object escape_decode(string text, string errors="strict") {
+        public static object escape_decode(string text, string errors = "strict") {
             StringBuilder res = new StringBuilder();
             for (int i = 0; i < text.Length; i++) {
 
@@ -201,10 +189,10 @@ namespace IronPython.Modules {
             }
 
             val = 0;
-            return false;            
+            return false;
         }
 
-        public static PythonTuple/*!*/ escape_encode(string text, string errors="strict") {
+        public static PythonTuple/*!*/ escape_encode(string text, string errors = "strict") {
             StringBuilder res = new StringBuilder();
             for (int i = 0; i < text.Length; i++) {
                 switch (text[i]) {
@@ -227,47 +215,31 @@ namespace IronPython.Modules {
 
         #region Latin-1 Functions
 
-       
-        public static object latin_1_decode(object input) {
-            return latin_1_decode(input, "strict");
-        }
 
-        public static object latin_1_decode(object input, string errors) {
-            return DoDecode(Encoding.GetEncoding("iso-8859-1"), input, errors);
-        }
+        public static object latin_1_decode(CodeContext context, object input, string errors = "strict") => DoDecode(context, null, Encoding.GetEncoding("iso-8859-1"), input, errors, true);
 
-        public static object latin_1_encode(object input) {
-            return latin_1_encode(input, "strict");
-        }
-
-        public static object latin_1_encode(object input, string errors) {
-            return DoEncode(Encoding.GetEncoding("iso-8859-1"), input, errors);
-        }
+        public static object latin_1_encode(object input, string errors = "strict") => DoEncode(Encoding.GetEncoding("iso-8859-1"), input, errors);
 
         #endregion
 
-        public static PythonTuple lookup(CodeContext/*!*/ context, string encoding) {
-            return PythonOps.LookupEncoding(context, encoding);
-        }
+        public static PythonTuple lookup(CodeContext/*!*/ context, string encoding) => PythonOps.LookupEncoding(context, encoding);
 
         [LightThrowing]
-        public static object lookup_error(CodeContext/*!*/ context, string name) {
-            return PythonOps.LookupEncodingError(context, name);
-        }
+        public static object lookup_error(CodeContext/*!*/ context, string name) => PythonOps.LookupEncodingError(context, name);
 
 #if FEATURE_ENCODING && FEATURE_WINDOWS
         #region MBCS Functions
 
-        public static PythonTuple mbcs_decode(CodeContext/*!*/ context, string input, [DefaultParameterValue("strict")]string errors, [DefaultParameterValue(false)]bool ignored) {
-            // CPython ignores the errors parameter
+        public static PythonTuple mbcs_decode(CodeContext/*!*/ context, string input, string errors = "strict", bool final = false) {
+            // CPython 2.x ignores the errors parameter
             return PythonTuple.MakeTuple(
                 StringOps.decode(context, input, Encoding.GetEncoding(0), "replace"),
                 Builtin.len(input)
             );
         }
 
-        public static PythonTuple mbcs_encode(CodeContext/*!*/ context, string input, [DefaultParameterValue("strict")]string errors) {
-            // CPython ignores the errors parameter
+        public static PythonTuple mbcs_encode(CodeContext/*!*/ context, string input, string errors = "strict") {
+            // CPython 2.x ignores the errors parameter
             return PythonTuple.MakeTuple(
                 StringOps.encode(context, input, Encoding.GetEncoding(0), "replace"),
                 Builtin.len(input)
@@ -277,45 +249,35 @@ namespace IronPython.Modules {
         #endregion
 #endif
 
-        public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, object input, [DefaultParameterValue("strict")]string errors) {
+        public static PythonTuple raw_unicode_escape_decode(CodeContext/*!*/ context, object input, string errors = "strict") {
             return PythonTuple.MakeTuple(
                 StringOps.decode(context, Converter.ConvertToString(input), "raw-unicode-escape", errors),
                 Builtin.len(input)
             );
         }
 
-        public static PythonTuple raw_unicode_escape_encode(CodeContext/*!*/ context, object input, [DefaultParameterValue("strict")]string errors) {
+        public static PythonTuple raw_unicode_escape_encode(CodeContext/*!*/ context, object input, string errors = "strict") {
             return PythonTuple.MakeTuple(
                 StringOps.encode(context, Converter.ConvertToString(input), "raw-unicode-escape", errors),
                 Builtin.len(input)
             );
         }
 
-        public static PythonTuple readbuffer_encode([BytesConversion]string input, string errors=null) {
+        public static PythonTuple readbuffer_encode([BytesConversion]string input, string errors = null) {
             return PythonTuple.MakeTuple(input, input.Length);
         }
 
-        public static void register(CodeContext/*!*/ context, object search_function) {
-            PythonOps.RegisterEncoding(context, search_function);
-        }
+        public static void register(CodeContext/*!*/ context, object search_function) => PythonOps.RegisterEncoding(context, search_function);
 
-        public static void register_error(CodeContext/*!*/ context, string name, object handler) {
-            PythonOps.RegisterEncodingError(context, name, handler);
-        }
+        public static void register_error(CodeContext/*!*/ context, string name, object handler) => PythonOps.RegisterEncodingError(context, name, handler);
 
         #region Unicode Escape Encoding
 
-        public static PythonTuple unicode_escape_decode(string input) {
-            throw PythonOps.NotImplementedError("unicode_escape_decode");
-        }
+        public static PythonTuple unicode_escape_decode(string input) => throw PythonOps.NotImplementedError("unicode_escape_decode");
 
-        public static PythonTuple unicode_escape_encode(string input) {
-            throw PythonOps.NotImplementedError("unicode_escape_encode");
-        }
+        public static PythonTuple unicode_escape_encode(string input) => throw PythonOps.NotImplementedError("unicode_escape_encode");
 
-        public static PythonTuple unicode_internal_decode(object input, [Optional]string errors) {
-            return utf_16_decode(input, errors, false);
-        }
+        public static PythonTuple unicode_internal_decode(CodeContext context, object input, string errors = "strict") => utf_16_decode(context, input, errors, false);
 
         public static PythonTuple unicode_internal_encode(object input, [Optional]string errors) {
             // length consumed is returned in bytes and for a UTF-16 string that is 2 bytes per char
@@ -330,49 +292,23 @@ namespace IronPython.Modules {
 
         #region Utf-16 Big Endian Functions
 
-        public static PythonTuple utf_16_be_decode(object input) {
-            return utf_16_be_decode(input, "strict", false);
-        }
+        public static PythonTuple utf_16_be_decode(CodeContext context, object input, string errors = "strict", bool final = false) => DoDecode(context, "utf16", Encoding.BigEndianUnicode, input, errors, final);
 
-        public static PythonTuple utf_16_be_decode(object input, string errors, [Optional]bool ignored) {
-            return DoDecode(Encoding.BigEndianUnicode, input, errors);
-        }
-
-        public static PythonTuple utf_16_be_encode(object input) {
-            return utf_16_be_encode(input, "strict");
-        }
-
-        public static PythonTuple utf_16_be_encode(object input, string errors) {
-            return DoEncode(Encoding.BigEndianUnicode, input, errors);
-        }
+        public static PythonTuple utf_16_be_encode(object input, string errors = "strict") => DoEncode(Encoding.BigEndianUnicode, input, errors);
 
         #endregion
 
         #region Utf-16 Functions
 
-        public static PythonTuple utf_16_decode(object input) {
-            return utf_16_decode(input, "strict", false);
-        }
+        public static PythonTuple utf_16_decode(CodeContext context, object input, string errors = "strict", bool final = false) => DoDecode(context, "utf16", Encoding.Unicode, input, errors, final);
 
-        public static PythonTuple utf_16_decode(object input, string errors, [Optional]bool ignored) {
-            return DoDecode(Encoding.Unicode, input, errors);
-        }
-
-        public static PythonTuple utf_16_encode(object input) {
-            return utf_16_encode(input, "strict");
-        }
-
-        public static PythonTuple utf_16_encode(object input, string errors) {
-            return DoEncode(Encoding.Unicode, input, errors, true);
-        }
+        public static PythonTuple utf_16_encode(object input, string errors = "strict") => DoEncode(Encoding.Unicode, input, errors, true);
 
         #endregion
 
-        public static PythonTuple utf_16_ex_decode(object input, [Optional]string errors) {
-            return utf_16_ex_decode(input, errors, null, null);
-        }
+        public static PythonTuple utf_16_ex_decode(CodeContext context, object input, string errors = "strict") => utf_16_ex_decode(context, input, errors, null, null);
 
-        public static PythonTuple utf_16_ex_decode(object input, string errors, object unknown1, object unknown2) {
+        public static PythonTuple utf_16_ex_decode(CodeContext context, object input, string errors, object unknown1, object unknown2) {
             byte[] lePre = Encoding.Unicode.GetPreamble();
             byte[] bePre = Encoding.BigEndianUnicode.GetPreamble();
 
@@ -404,98 +340,50 @@ namespace IronPython.Modules {
                 }
             }
 
-            PythonTuple res = utf_16_decode(input, errors, false) as PythonTuple;
+            PythonTuple res = utf_16_decode(context, input, errors, false) as PythonTuple;
             return PythonTuple.MakeTuple(res[0], res[1], 0);
         }
 
         #region Utf-16 Le Functions
 
-        public static PythonTuple utf_16_le_decode(object input) {
-            return utf_16_le_decode(input, "strict", false);
-        }
+        public static PythonTuple utf_16_le_decode(CodeContext context, object input, string errors = "strict", bool final = false) => utf_16_decode(context, input, errors, final);
 
-        public static PythonTuple utf_16_le_decode(object input, string errors, [Optional]bool ignored) {
-            return utf_16_decode(input, errors, false);
-        }
-
-        public static PythonTuple utf_16_le_encode(object input) {
-            return utf_16_le_encode(input, "strict");
-        }
-
-        public static PythonTuple utf_16_le_encode(object input, string errors) {
-            return DoEncode(Encoding.Unicode, input, errors);
-        }
+        public static PythonTuple utf_16_le_encode(object input, string errors = "strict") => DoEncode(Encoding.Unicode, input, errors);
 
         #endregion
 
         #region Utf-7 Functions
 
 #if FEATURE_ENCODING
-        public static PythonTuple utf_7_decode(object input) {
-            return utf_7_decode(input, "strict", false);
-        }
 
-        public static PythonTuple utf_7_decode(object input, string errors, [Optional]bool ignored) {
-            return DoDecode(Encoding.UTF7, input, errors);
-        }
+        public static PythonTuple utf_7_decode(CodeContext context, object input, string errors = "strict", bool final = false) => DoDecode(context, "utf7", Encoding.UTF7, input, errors, final);
 
-        public static PythonTuple utf_7_encode(object input) {
-            return utf_7_encode(input, "strict");
-        }
+        public static PythonTuple utf_7_encode(object input, string errors = "strict") => DoEncode(Encoding.UTF7, input, errors);
 
-        public static PythonTuple utf_7_encode(object input, string errors) {
-            return DoEncode(Encoding.UTF7, input, errors);
-        }
 #endif
 
         #endregion
 
         #region Utf-8 Functions
 
-        public static PythonTuple utf_8_decode(object input) {
-            return utf_8_decode(input, "strict", false);
-        }
+        public static PythonTuple utf_8_decode(CodeContext context, object input, string errors = "strict", bool final = false) => DoDecode(context, "utf8", Encoding.UTF8, input, errors, final);
 
-        public static PythonTuple utf_8_decode(object input, string errors, [Optional]bool ignored) {
-            return DoDecode(Encoding.UTF8, input, errors);
-        }
-
-        public static PythonTuple utf_8_encode(object input) {
-            return utf_8_encode(input, "strict");
-        }
-
-        public static PythonTuple utf_8_encode(object input, string errors) {
-            return DoEncode(Encoding.UTF8, input, errors);
-        }
+        public static PythonTuple utf_8_encode(object input, string errors = "strict") => DoEncode(Encoding.UTF8, input, errors);
 
         #endregion
 
 #if FEATURE_ENCODING
         #region Utf-32 Functions
 
-        public static PythonTuple utf_32_decode(object input) {
-            return utf_32_decode(input, "strict");
-        }
+        public static PythonTuple utf_32_decode(CodeContext context, object input, string errors = "strict", bool final = false) => DoDecode(context, "utf32", Encoding.UTF32, input, errors, final);
 
-        public static PythonTuple utf_32_decode(object input, string errors) {
-            return DoDecode(Encoding.UTF32, input, errors);
-        }
-
-        public static PythonTuple utf_32_encode(object input) {
-            return utf_32_encode(input, "strict");
-        }
-
-        public static PythonTuple utf_32_encode(object input, string errors) {
-            return DoEncode(Encoding.UTF32, input, errors, true);
-        }
+        public static PythonTuple utf_32_encode(object input, string errors = "strict") => DoEncode(Encoding.UTF32, input, errors, true);
 
         #endregion
 
-        public static PythonTuple utf_32_ex_decode(object input, [Optional]string errors) {
-            return utf_32_ex_decode(input, errors, null, null);
-        }
+        public static PythonTuple utf_32_ex_decode(CodeContext context, object input, string errors = "strict") => utf_32_ex_decode(context, input, errors, null, null);
 
-        public static PythonTuple utf_32_ex_decode(object input, string errors, object unknown1, object unknown2) {
+        public static PythonTuple utf_32_ex_decode(CodeContext context, object input, string errors, object byteorder, object final) {
             byte[] lePre = Encoding.UTF32.GetPreamble();
 
             string instr = Converter.ConvertToString(input);
@@ -512,27 +400,15 @@ namespace IronPython.Modules {
                 }
             }
 
-            PythonTuple res = utf_32_decode(input, errors) as PythonTuple;
+            PythonTuple res = utf_32_decode(context, input, errors) as PythonTuple;
             return PythonTuple.MakeTuple(res[0], res[1], 0);
         }
 
         #region Utf-32 Le Functions
 
-        public static PythonTuple utf_32_le_decode(object input) {
-            return utf_32_le_decode(input, "strict", false);
-        }
+        public static PythonTuple utf_32_le_decode(CodeContext context, object input, string errors = "strict", bool final = false) => utf_32_decode(context, input, errors, final);
 
-        public static PythonTuple utf_32_le_decode(object input, string errors, [Optional]bool ignored) {
-            return utf_32_decode(input, errors);
-        }
-
-        public static PythonTuple utf_32_le_encode(object input) {
-            return utf_32_le_encode(input, "strict");
-        }
-
-        public static PythonTuple utf_32_le_encode(object input, string errors) {
-            return DoEncode(Encoding.UTF32, input, errors);
-        }
+        public static PythonTuple utf_32_le_encode(object input, string errors = "strict") => DoEncode(Encoding.UTF32, input, errors);
 
         #endregion
 
@@ -546,112 +422,33 @@ namespace IronPython.Modules {
             }
         }
 
-        public static PythonTuple utf_32_be_decode(object input) {
-            return utf_32_be_decode(input, "strict", false);
-        }
+        public static PythonTuple utf_32_be_decode(CodeContext context, object input, string errors = "strict", bool final = false) => DoDecode(context, "utf32", UTF32BE, input, errors, final);
 
-        public static PythonTuple utf_32_be_decode(object input, string errors, [Optional]bool ignored) {
-            return DoDecode(UTF32BE, input, errors);
-        }
-
-        public static PythonTuple utf_32_be_encode(object input) {
-            return utf_32_be_encode(input, "strict");
-        }
-
-        public static PythonTuple utf_32_be_encode(object input, string errors) {
-            return DoEncode(UTF32BE, input, errors);
-        }
+        public static PythonTuple utf_32_be_encode(object input, string errors = "strict") => DoEncode(UTF32BE, input, errors);
 
         #endregion
 #endif
 
-
         #region Private implementation
 
-        private static PythonTuple DoDecode(Encoding encoding, object input, string errors) {
-            return DoDecode(encoding, input, errors, false);
-        }
-
-        private static PythonTuple DoDecode(Encoding encoding, object input, string errors, bool fAlwaysThrow) {
+        private static PythonTuple DoDecode(CodeContext context, string encodingName, Encoding encoding, object input, string errors, bool final) {
             // input should be character buffer of some form...
             string res;
 
             if (!Converter.TryConvertToString(input, out res)) {
-                Bytes tempBytes = input as Bytes;
-                if (tempBytes == null) {
-                    throw PythonOps.TypeErrorForBadInstance("argument 1 must be string, got {0}", input);
-                } else {
+                if (input is Bytes tempBytes) {
                     res = tempBytes.ToString();
+                } else {
+                    throw PythonOps.TypeErrorForBadInstance("argument 1 must be string, got {0}", input);
                 }
             }
 
-            int preOffset = CheckPreamble(encoding, res);
+            var decoded = StringOps.DoDecode(context, res, errors, encodingName, encoding, final, out int numBytes);
 
-            byte[] bytes = new byte[res.Length - preOffset];
-            for (int i = 0; i < bytes.Length; i++) {
-                bytes[i] = (byte)res[i + preOffset];
-            }
-
-#if FEATURE_ENCODING    // DecoderFallback
-            encoding = (Encoding)encoding.Clone();
-            ExceptionFallBack fallback = null;
-            if (fAlwaysThrow) {
-                encoding.DecoderFallback = DecoderFallback.ExceptionFallback;
-            } else {
-                fallback = (encoding is UTF8Encoding && DotNet) ?
-                    // This is a workaround for a bug, see ExceptionFallbackBufferUtf8DotNet
-                    // for more details.
-                    new ExceptionFallBackUtf8DotNet(bytes):
-                    new ExceptionFallBack(bytes);
-                encoding.DecoderFallback = fallback;
-            }
-#endif
-            string decoded = encoding.GetString(bytes, 0, bytes.Length);
-            int badByteCount = 0;
-
-
-#if FEATURE_ENCODING    // DecoderFallback
-            if (!fAlwaysThrow) {
-                byte[] badBytes = fallback.buffer.badBytes;
-                if (badBytes != null) {
-                    badByteCount = badBytes.Length;
-                }
-            }
-#endif
-
-            PythonTuple tuple = PythonTuple.MakeTuple(decoded, bytes.Length - badByteCount);
-            return tuple;
+            return PythonTuple.MakeTuple(decoded, numBytes);
         }
 
-
-        internal static readonly bool DotNet;
-
-        static PythonCodecs() {
-            DotNet = Type.GetType("Mono.Runtime") == null;
-        }
-
-
-        private static int CheckPreamble(Encoding enc, string buffer) {
-            byte[] preamble = enc.GetPreamble();
-
-            if (preamble.Length != 0 && buffer.Length >= preamble.Length) {
-                bool hasPreamble = true;
-                for (int i = 0; i < preamble.Length; i++) {
-                    if (preamble[i] != (byte)buffer[i]) {
-                        hasPreamble = false;
-                        break;
-                    }
-                }
-                if (hasPreamble) {
-                    return preamble.Length;
-                }
-            }
-            return 0;
-        }
-
-        private static PythonTuple DoEncode(Encoding encoding, object input, string errors) {
-            return DoEncode(encoding, input, errors, false);
-        }
+        private static PythonTuple DoEncode(Encoding encoding, object input, string errors) => DoEncode(encoding, input, errors, false);
 
         private static PythonTuple DoEncode(Encoding encoding, object input, string errors, bool includePreamble) {
             // input should be some Unicode object
@@ -695,8 +492,8 @@ namespace IronPython.Modules {
 #if FEATURE_ENCODING    // Encoding
 
     class EncodingMapEncoding : Encoding {
-        private EncodingMap _map;
-        private string _errors;
+        private readonly EncodingMap _map;
+        private readonly string _errors;
 
         public EncodingMapEncoding(EncodingMap map, string errors) {
             _map = map;
@@ -707,10 +504,9 @@ namespace IronPython.Modules {
             int byteCount = 0;
             int charEnd = index + count;
             while (index < charEnd) {
-                char val;
                 char c = chars[index];
 
-                if (!_map.Mapping.TryGetValue(c, out val)) {
+                if (!_map.Mapping.TryGetValue(c, out _)) {
                     EncoderFallbackBuffer efb = EncoderFallback.CreateFallbackBuffer();
                     if (efb.Fallback(c, index)) {
                         byteCount += efb.Remaining;
@@ -729,7 +525,7 @@ namespace IronPython.Modules {
             while (charIndex < charEnd) {
                 char c = chars[charIndex];
                 char val;
-                
+
                 if (!_map.Mapping.TryGetValue((int)c, out val)) {
                     EncoderFallbackBuffer efb = EncoderFallback.CreateFallbackBuffer();
                     if (efb.Fallback(c, charIndex)) {
@@ -752,8 +548,8 @@ namespace IronPython.Modules {
             int outputChars = 0;
             while (index < byteEnd) {
                 byte b = bytes[index];
-                char val;
-                if (!_map.Mapping.TryGetValue(b, out val)) {
+
+                if (!_map.Mapping.TryGetValue(b, out _)) {
                     DecoderFallbackBuffer dfb = DecoderFallback.CreateFallbackBuffer();
                     if (dfb.Fallback(new[] { b }, 0)) {
                         outputChars += dfb.Remaining;
@@ -802,8 +598,8 @@ namespace IronPython.Modules {
     }
 
     class CharmapEncoding : Encoding {
-        private IDictionary<object, object> _map;
-        private string _errors;
+        private readonly IDictionary<object, object> _map;
+        private readonly string _errors;
 
         public CharmapEncoding(IDictionary<object, object> map, string errors) {
             _map = map;
@@ -813,11 +609,9 @@ namespace IronPython.Modules {
 
         private void FixupMap() {
             // this is required if someone passes in a mapping like { 'a' : None }
-            foreach(var k in _map) {
-                if(k.Key is string) {
-                    var s = (string)k.Key;
-                    if(s.Length == 1)
-                        _map[(int)s[0]] = k.Value;
+            foreach (var k in _map) {
+                if (k.Key is string s && s.Length == 1) {
+                    _map[(int)s[0]] = k.Value;
                 }
             }
         }
@@ -835,11 +629,11 @@ namespace IronPython.Modules {
                     if (efb.Fallback(c, index)) {
                         byteCount += efb.Remaining;
                     }
-                } else if(val == null) { 
+                } else if (val == null) {
                     throw PythonOps.UnicodeEncodeError("charmap", c, index, "'charmap' codec can't encode character u'\\x{0:x}' in position {1}: character maps to <undefined>", (int)c, index);
                 } else if (val is string) {
                     byteCount += ((string)val).Length;
-                } else if(val is int) {
+                } else if (val is int) {
                     byteCount++;
                 } else {
                     throw PythonOps.TypeError("charmap must be an int, str, or None");
@@ -852,7 +646,7 @@ namespace IronPython.Modules {
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) {
             int charEnd = charIndex + charCount;
             int outputBytes = 0;
-            while(charIndex < charEnd) {
+            while (charIndex < charEnd) {
                 char c = chars[charIndex];
                 object val;
                 object obj = (int)c;
@@ -865,7 +659,7 @@ namespace IronPython.Modules {
                             outputBytes++;
                         }
                     }
-                } else if(val == null) {
+                } else if (val == null) {
                     throw PythonOps.UnicodeEncodeError("charmap", c, charIndex, "'charmap' codec can't encode character u'\\x{0:x}' in position {1}: character maps to <undefined>", (int)c, charIndex);
                 } else if (val is string) {
                     string v = val as string;
@@ -873,7 +667,7 @@ namespace IronPython.Modules {
                         bytes[byteIndex++] = (byte)v[i];
                         outputBytes++;
                     }
-                } else if(val is int) {
+                } else if (val is int) {
                     bytes[byteIndex++] = (byte)(int)val;
                     outputBytes++;
                 } else {
@@ -900,7 +694,7 @@ namespace IronPython.Modules {
                     }
                 } else if (val is string) {
                     outputChars += ((string)val).Length;
-                } else if(val is int) {
+                } else if (val is int) {
                     outputChars++;
                 } else {
                     throw PythonOps.TypeError("charmap must be an int, str, or None");
@@ -922,7 +716,7 @@ namespace IronPython.Modules {
                     DecoderFallbackBuffer dfb = DecoderFallback.CreateFallbackBuffer();
                     if (dfb.Fallback(new[] { b }, 0)) {
                         while (dfb.Remaining != 0) {
-                            chars[charIndex++] = dfb.GetNextChar();                            
+                            chars[charIndex++] = dfb.GetNextChar();
                             outputChars++;
                         }
                     }
@@ -954,91 +748,5 @@ namespace IronPython.Modules {
         }
     }
 
-    class ExceptionFallBack : DecoderFallback {
-        internal ExceptionFallbackBuffer buffer;
-
-        // This ctor can be removed as soon as workaround for utf8 encoding in .net is
-        // no longer necessary.
-        protected ExceptionFallBack() {
-        }
-
-        public ExceptionFallBack(byte[] bytes) {
-            buffer = new ExceptionFallbackBuffer(bytes);
-        }
-
-        public override DecoderFallbackBuffer CreateFallbackBuffer() {
-            return buffer;
-        }
-
-        public override int MaxCharCount {
-            get { return 100; }
-        }
-    }
-
-    class ExceptionFallbackBuffer : DecoderFallbackBuffer {
-        internal byte[] badBytes;
-        protected byte[] inputBytes;
-
-        public ExceptionFallbackBuffer(byte[] bytes) {
-            inputBytes = bytes;
-        }
-
-        public override bool Fallback(byte[] bytesUnknown, int index) {
-            if (index > 0 && index + bytesUnknown.Length != inputBytes.Length) {
-                throw PythonOps.UnicodeDecodeError(
-                    String.Format("failed to decode bytes at index: {0}", index), bytesUnknown, index);
-            }
-            // just some bad bytes at the end
-            badBytes = bytesUnknown;
-            return false;
-        }
-
-        public override char GetNextChar() {
-            return ' ';
-        }
-
-        public override bool MovePrevious() {
-            return false;
-        }
-
-        public override int Remaining {
-            get { return 0; }
-        }
-    }
-
-    // This class can be removed as soon as workaround for utf8 encoding in .net is
-    // no longer necessary.
-    class ExceptionFallBackUtf8DotNet : ExceptionFallBack {
-        public ExceptionFallBackUtf8DotNet(byte[] bytes) {
-            buffer = new ExceptionFallbackBufferUtf8DotNet(bytes);
-        }
-    }
-
-    // This class can be removed as soon as workaround for utf8 encoding in .net is
-    // no longer necessary.
-    class ExceptionFallbackBufferUtf8DotNet : ExceptionFallbackBuffer {
-        private bool ignoreNext = false;
-
-        public ExceptionFallbackBufferUtf8DotNet(byte[] bytes) : base(bytes) {
-        }
-
-        public override bool Fallback(byte[] bytesUnknown, int index) {
-            // In case of dot net and utf-8 value of index does not conform to documentation provided by
-            // Microsoft http://msdn.microsoft.com/en-us/library/bdftay9c%28v=vs.100%29.aspx
-            // The value of index is mysteriously decreased by the size of bytesUnknown
-            // Tested on Windows 7 64, .NET 4.0.30319.18408, all recommended patches as of 06.02.2014
-            if (ignoreNext) {
-                // dot net sometimes calls second time after this method returns false
-                // if this is the case, do nothing
-                return false;
-            }
-            // adjust index
-            index = index + bytesUnknown.Length;
-            ignoreNext = true;
-            return base.Fallback(bytesUnknown, index);
-        }
-
-    }
 #endif
-
 }

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -1727,7 +1727,13 @@ namespace IronPython.Runtime.Operations {
         private static DecoderFallback ReplacementFallback = new DecoderReplacementFallback("\ufffd");
 #endif
 
-        internal static string DoDecode(CodeContext context, string s, string errors, string encoding, Encoding e) {
+        internal static string DoDecode(CodeContext context, string s, string errors, string encoding, Encoding e) => DoDecode(context, s, errors, encoding, e, true, out _);
+
+        internal static string DoDecode(CodeContext context, string s, string errors, string encoding, Encoding e, bool final, out int numBytes) {
+            byte[] bytes = s.MakeByteArray();
+            int start = GetStartingOffset(e, bytes);
+            numBytes = bytes.Length - start;
+
 #if FEATURE_ENCODING
             // CLR's encoder exceptions have a 1-1 mapping w/ Python's encoder exceptions
             // so we just clone the encoding & set the fallback to throw in strict mode.
@@ -1736,7 +1742,7 @@ namespace IronPython.Runtime.Operations {
             switch (errors) {
                 case "backslashreplace":
                 case "xmlcharrefreplace":
-                case "strict": e.DecoderFallback = DecoderFallback.ExceptionFallback; break;
+                case "strict": e.DecoderFallback = final ? DecoderFallback.ExceptionFallback : new ExceptionFallBack(numBytes, e is UTF8Encoding); break;
                 case "replace": e.DecoderFallback = ReplacementFallback; break;
                 case "ignore": e.DecoderFallback = new PythonDecoderFallback(encoding, s, null); break;
                 default:
@@ -1745,10 +1751,18 @@ namespace IronPython.Runtime.Operations {
             }
 #endif
 
-            byte[] bytes = s.MakeByteArray();
-            int start = GetStartingOffset(e, bytes);
+            string decoded = e.GetString(bytes, start, numBytes);
 
-            return e.GetString(bytes, start, bytes.Length - start);
+#if FEATURE_ENCODING
+            if (e.DecoderFallback is ExceptionFallBack fallback) {
+                byte[] badBytes = fallback.buffer.badBytes;
+                if (badBytes != null) {
+                    numBytes -= badBytes.Length;
+                }
+            }
+#endif
+
+            return decoded;
         }
 
         /// <summary>
@@ -1756,20 +1770,18 @@ namespace IronPython.Runtime.Operations {
         /// </summary>
         private static int GetStartingOffset(Encoding e, byte[] bytes) {
             byte[] preamble = e.GetPreamble();
-            int start = 0;
-            if (bytes.Length >= preamble.Length) {
-                bool differ = false;
+
+            if (preamble.Length != 0 && bytes.Length >= preamble.Length) {
                 for (int i = 0; i < preamble.Length; i++) {
                     if (bytes[i] != preamble[i]) {
-                        differ = true;
+                        return 0;
                     }
                 }
 
-                if (!differ) {
-                    start = preamble.Length;
-                }
+                return preamble.Length;
             }
-            return start;
+
+            return 0;
         }
 
         private static string RawEncode(CodeContext/*!*/ context, string s, object encodingType, string errors) {
@@ -1829,7 +1841,6 @@ namespace IronPython.Runtime.Operations {
 #endif
             return PythonOps.MakeString(e.GetPreamble(), e.GetBytes(s));
         }
-
 
         private static string UserDecodeOrEncode(object function, string data, string errors) {
             object res;
@@ -2682,12 +2693,104 @@ namespace IronPython.Runtime.Operations {
                 return byteCount;
             }
         }
+
+        class ExceptionFallBack : DecoderFallback {
+            internal ExceptionFallbackBuffer buffer;
+
+            #region check for Utf8 Fallback issue
+
+            static bool isUtf8Bugged;
+
+            private class TestUtf8DecoderFallBack : DecoderFallback {
+                public override int MaxCharCount => 0;
+
+                public override DecoderFallbackBuffer CreateFallbackBuffer() => new TestUtf8DecoderFallbackBuffer();
+            }
+
+            private class TestUtf8DecoderFallbackBuffer : DecoderFallbackBuffer {
+                public override int Remaining => 0;
+
+                public override bool Fallback(byte[] bytesUnknown, int index) {
+                    if (index < 0) throw new Exception();
+                    return false;
+                }
+
+                public override char GetNextChar() => (char)0;
+
+                public override bool MovePrevious() => false;
+            }
+
+            static ExceptionFallBack() {
+                var e = (Encoding)Encoding.UTF8.Clone();
+                e.DecoderFallback = new TestUtf8DecoderFallBack();
+                try { e.GetString(new byte[] { 255 }); } catch { isUtf8Bugged = true; }
+            }
+
+            #endregion
+
+            public ExceptionFallBack(int length, bool isUtf8 = false) {
+                buffer = isUtf8 && isUtf8Bugged ? new ExceptionFallbackBufferUtf8DotNet(length) : new ExceptionFallbackBuffer(length);
+            }
+
+            public override DecoderFallbackBuffer CreateFallbackBuffer() => buffer;
+
+            public override int MaxCharCount => 0;
+        }
+
+        class ExceptionFallbackBuffer : DecoderFallbackBuffer {
+            private readonly int length;
+            internal byte[] badBytes;
+
+            public ExceptionFallbackBuffer(int length) {
+                this.length = length;
+            }
+
+            public override bool Fallback(byte[] bytesUnknown, int index) {
+                if (index > 0 && index + bytesUnknown.Length != length) {
+                    throw new Exception();
+                }
+                // just some bad bytes at the end
+                badBytes = bytesUnknown;
+                return false;
+            }
+
+            public override char GetNextChar() => (char)0;
+
+            public override bool MovePrevious() => false;
+
+            public override int Remaining => 0;
+        }
+
+        // This class can be removed as soon as workaround for utf8 encoding in .net is
+        // no longer necessary.
+        class ExceptionFallbackBufferUtf8DotNet : ExceptionFallbackBuffer {
+            private bool ignoreNext = false;
+
+            public ExceptionFallbackBufferUtf8DotNet(int length) : base(length) { }
+
+            public override bool Fallback(byte[] bytesUnknown, int index) {
+                // In case of dot net and utf-8 value of index does not conform to documentation provided by
+                // Microsoft http://msdn.microsoft.com/en-us/library/bdftay9c%28v=vs.100%29.aspx
+                // The value of index is mysteriously decreased by the size of bytesUnknown
+                // Tested on Windows 7 64, .NET 4.0.30319.18408, all recommended patches as of 06.02.2014
+                if (ignoreNext) {
+                    // dot net sometimes calls second time after this method returns false
+                    // if this is the case, do nothing
+                    return false;
+                }
+                // adjust index
+                index = index + bytesUnknown.Length;
+                ignoreNext = true;
+                return base.Fallback(bytesUnknown, index);
+            }
+        }
+
 #endif
+
         #endregion
 
         public static string/*!*/ __repr__(string/*!*/ self) {
             return StringOps.Quote(self);
         }
-
     }
 }

--- a/Src/IronPython/Runtime/Operations/StringOps.cs
+++ b/Src/IronPython/Runtime/Operations/StringOps.cs
@@ -2747,7 +2747,7 @@ namespace IronPython.Runtime.Operations {
 
             public override bool Fallback(byte[] bytesUnknown, int index) {
                 if (index > 0 && index + bytesUnknown.Length != length) {
-                    throw new Exception();
+                    throw PythonOps.UnicodeDecodeError($"failed to decode bytes at index: {index}", bytesUnknown, index);
                 }
                 // just some bad bytes at the end
                 badBytes = bytesUnknown;

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -1138,5 +1138,18 @@ class C:
         for p in ('oo', 'o*', '?o'):
             self.assertEqual(os.path.abspath(prefix + p), os.path.abspath(prefix) + p)
 
+    def test_ipy2_gh112(self):
+        """https://github.com/IronLanguages/ironpython2/issues/112"""
+
+        import io
+
+        path = 'test.tmp'
+        with open(path, 'wb') as f:
+            f.write(u'hyv\xe4'.encode('UTF-8'))
+        try:
+            with io.open(path, encoding='ASCII', errors='ignore') as f:
+                self.assertEqual(f.read(), "hyv")
+        finally:
+            os.remove(path)
 
 run_test(__name__)


### PR DESCRIPTION
- `DoDecode` in `StringOps` and `_codecs` were almost the same, refactored `StringOps.DoDecode` to be able usable in both cases.
- Make use of the `final` argument in most `_codecs` methods instead of ignoring it.
- There was a workaround for a .NET bug that was hardcoded, made it a runtime check instead.

Resolves https://github.com/IronLanguages/ironpython2/issues/112.