### PR TITLE
Update .editorconfig to match style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ csharp_new_line_before_open_brace = none
 csharp_new_line_before_else = false
 csharp_new_line_before_catch = false
 csharp_new_line_before_finally = false
+csharp_space_after_keywords_in_control_flow_statements = true
 
 # disable default VS2017 naming rule
 dotnet_naming_rule.methods_and_properties_must_be_pascal_case.severity = none


### PR DESCRIPTION
Most of the codebase is set up with `csharp_space_after_keywords_in_control_flow_statements = true` so add it to the `.editorconfig`.
```
if (bla) { } // csharp_space_after_keywords_in_control_flow_statements = true
if(bla) { } // csharp_space_after_keywords_in_control_flow_statements = false
```
