### PR TITLE
Fix bug in array and add fast paths

### DIFF
--- a/Src/IronPython.Modules/array.cs
+++ b/Src/IronPython.Modules/array.cs
@@ -42,7 +42,7 @@ namespace IronPython.Modules {
         public class array : IPythonArray, IEnumerable, IWeakReferenceable, ICollection, ICodeFormattable, IList<object>, IStructuralEquatable
         {
             private ArrayData _data;
-            private char _typeCode;
+            private readonly char _typeCode;
             private WeakRefTracker _tracker;
 
             public array([BytesConversion]string type, [Optional]object initializer) {
@@ -689,6 +689,13 @@ namespace IronPython.Modules {
             }
 
             internal byte[] ToByteArray() {
+                if (_data is ArrayData<byte> data) {
+                    Debug.Assert(_typeCode == 'B');
+                    var res = new byte[data.Length];
+                    Array.Copy(data.Data, res, data.Length);
+                    return res;
+                }
+
                 return ToStream().ToArray();
             }
 
@@ -698,6 +705,15 @@ namespace IronPython.Modules {
 
             internal void FromStream(Stream ms) {
                 BinaryReader br = new BinaryReader(ms);
+
+                if (_data is ArrayData<byte> data) {
+                    Debug.Assert(_typeCode == 'B');
+                    var length = (int)ms.Length;
+                    data.EnsureSize(data.Length + length);
+                    Array.Copy(br.ReadBytes(length), 0, data.Data, data.Length, length);
+                    data.Length += length;
+                    return;
+                }
 
                 for (int i = 0; i < ms.Length / itemsize; i++) {
                     object value;
@@ -898,7 +914,11 @@ namespace IronPython.Modules {
 
                 public void EnsureSize(int size) {
                     if (_data.Length < size) {
-                        Array.Resize(ref _data, _data.Length * 2);
+                        var length = _data.Length;
+                        while (length < size) {
+                            length *= 2;
+                        }
+                        Array.Resize(ref _data, length);
                         if (_dataHandle != null) {
                             _dataHandle.Value.Free();
                             _dataHandle = null;

--- a/Tests/modules/type_related/test_array.py
+++ b/Tests/modules/type_related/test_array.py
@@ -51,7 +51,7 @@ class ArrayTest(unittest.TestCase):
         x = array.array('i', [1,2,3])
         y = x.__copy__()
         self.assertTrue(id(x) != id(y), "copy should copy")
-        
+
         y = x.__deepcopy__(x)
         self.assertTrue(id(x) != id(y), "copy should copy")
 
@@ -155,14 +155,14 @@ class ArrayTest(unittest.TestCase):
                     (2**16)-2, (2**16)-1, (2**16), (2**16)+1, (2**16)+2,
                     (2**32)-2, (2**32)-1,
                     ]:
-                    
+        
             temp_array1 = array.array('I', [x])
             self.assertEqual(temp_array1[0], x)
-            
+
             temp_array1 = array.array('I', [x, x])
             self.assertEqual(temp_array1[0], x)
             self.assertEqual(temp_array1[1], x)
-            
+
         for x in [  (2**32), (2**32)+1, (2**32)+2 ]:
             self.assertRaises(OverflowError, array.array, 'I', [x])
 
@@ -181,7 +181,7 @@ class ArrayTest(unittest.TestCase):
         a = array.array('B', [0]) * 2L
         self.assertEqual(2, len(a))
         self.assertEqual("array('B', [0, 0])", str(a))
-        
+
         #--b
         self.assertEqual(array.array('b', 'foo'), array.array('b', [102, 111, 111]))
 
@@ -247,7 +247,7 @@ class ArrayTest(unittest.TestCase):
         TODO
         '''
         pass
-        
+
     def test_array___rmul__(self):
         '''
         TODO
@@ -339,10 +339,13 @@ class ArrayTest(unittest.TestCase):
         pass
 
     def test_array_fromunicode(self):
-        '''
-        TODO
-        '''
-        pass
+        # TODO: add more tests
+        a = array.array('u')
+        a.fromunicode(u"a"*20)
+        self.assertEqual(len(a), 20)
+        a.fromunicode(u"b"*100)
+        self.assertEqual(len(a), 120)
+        self.assertEqual(a.tolist(), [u"a"]*20 + [u"b"]*100)
 
     def test_array_index(self):
         '''
@@ -457,8 +460,8 @@ class ArrayTest(unittest.TestCase):
         a2 = array.array('b', 'a')
         a2[:-1] = a2
         self.assertEqual(str(a2), "array('b', [97, 97])")
-        a2[:-(2**64)-1] = a2 
-        self.assertEqual(str(a2), "array('b', [97, 97, 97, 97])")  
+        a2[:-(2**64)-1] = a2
+        self.assertEqual(str(a2), "array('b', [97, 97, 97, 97])")
 
 
     def test_cp9350(self):
@@ -469,7 +472,7 @@ class ArrayTest(unittest.TestCase):
         for i in [2, 2L]:
             a = array.array('B', [0]) * i
             self.assertEqual(a, array.array('B', [0, 0]))
-        
+
         for i in [2**8, long(2**8)]:
             a = array.array('B', [1]) * i
             self.assertEqual(a, array.array('B', [1]*2**8))
@@ -497,40 +500,40 @@ class ArrayTest(unittest.TestCase):
         '''
         #--Postive
         a = array.array('b', 'a')
-        for i in [  0L, 1L, 2L, 3L, 32766L, 32767L, 32768L, 65534L, 65535L, 65536L, 
+        for i in [  0L, 1L, 2L, 3L, 32766L, 32767L, 32768L, 65534L, 65535L, 65536L,
                     456720545L, #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=24314
                     ]:
             self.assertEqual(i,
                     len(i*a))
             self.assertEqual(i, len(a*i))
-        
+
         #--Negative
         self.assertRaises(OverflowError, lambda: 4567206470L*a)
         self.assertRaises(OverflowError, lambda: a*4567206470L)
         if not is_mono: # these do not fail on Mono
             self.assertRaises(MemoryError,   lambda: 2147483646L*a)
             self.assertRaises(MemoryError,   lambda: a*2147483646L)
-        
+
         #--Positive
         a = array.array('b', 'abc')
         del a[:]
         self.assertEqual(a, array.array('b', ''))
-        
+
         a = array.array('b', 'abc')
         del a[0:]
         self.assertEqual(a, array.array('b', ''))
-        
+
         a = array.array('b', 'abc')
         del a[1:1]
         self.assertEqual(a, array.array('b', 'abc'))
-        
+
         a = array.array('b', 'abc')
         del a[1:4]
         self.assertEqual(a, array.array('b', 'a'))
-        
+
         a = array.array('b', 'abc')
         del a[0:1]
         self.assertEqual(a, array.array('b', 'bc'))
-    
-    
+
+
 run_test(__name__)


### PR DESCRIPTION
Adds some fast paths for bytes. Specifically this is to speed up `struct.pack_into` used with an `array.array('B')`. In my code that uses this I get a 20x speedup.

The bug that was fixed is in `EnsureSize`. Here is a test case:
```
import array
a = array.array('u')
a.fromunicode(u"a"*20)
```