### PR TITLE
Update tokenizer and code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,8 @@
 root = true
 
 [*]
+insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
@@ -15,10 +17,18 @@ csharp_new_line_before_catch = false
 csharp_new_line_before_finally = false
 csharp_space_after_keywords_in_control_flow_statements = true
 
+# use language keywords instead of BCL types
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
 # disable default VS2017 naming rule
 dotnet_naming_rule.methods_and_properties_must_be_pascal_case.severity = none
 dotnet_naming_rule.methods_and_properties_must_be_pascal_case.symbols  = method_and_property_symbols
 dotnet_naming_rule.methods_and_properties_must_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.method_and_property_symbols.applicable_kinds           = method;property
+dotnet_naming_symbols.method_and_property_symbols.applicable_kinds           = method, property
 dotnet_naming_symbols.method_and_property_symbols.applicable_accessibilities = *
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# enforce some code styles
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:error
+csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:error

--- a/Src/IronPython/Compiler/Ast/AstMethods.cs
+++ b/Src/IronPython/Compiler/Ast/AstMethods.cs
@@ -27,7 +27,7 @@ using IronPython.Runtime.Operations;
 using IronPython.Runtime.Types;
 
 namespace IronPython.Compiler.Ast {
-    static class AstMethods {
+    internal static class AstMethods {
         public static readonly MethodInfo IsTrue = GetMethod((Func<object, bool>)PythonOps.IsTrue);
         public static readonly MethodInfo RaiseAssertionError = GetMethod((Action<CodeContext, object>)PythonOps.RaiseAssertionError);
         public static readonly MethodInfo RaiseAssertionErrorNoMessage = GetMethod((Action<CodeContext>)PythonOps.RaiseAssertionError);

--- a/Src/IronPython/Compiler/Ast/PythonAst.cs
+++ b/Src/IronPython/Compiler/Ast/PythonAst.cs
@@ -63,7 +63,7 @@ namespace IronPython.Compiler.Ast {
 
         internal const string GlobalContextName = "$globalContext";
         internal static MSAst.ParameterExpression _functionCode = Ast.Variable(typeof(FunctionCode), "$functionCode");
-        internal readonly static MSAst.ParameterExpression/*!*/ _globalArray = Ast.Parameter(typeof(PythonGlobal[]), "$globalArray");
+        internal static readonly MSAst.ParameterExpression/*!*/ _globalArray = Ast.Parameter(typeof(PythonGlobal[]), "$globalArray");
         internal static readonly MSAst.ParameterExpression/*!*/ _globalContext = Ast.Parameter(typeof(CodeContext), GlobalContextName);
         internal static readonly ReadOnlyCollection<MSAst.ParameterExpression> _arrayFuncParams = new ReadOnlyCollectionBuilder<MSAst.ParameterExpression>(new[] { _globalContext, _functionCode }).ToReadOnlyCollection();
 

--- a/Src/IronPython/Compiler/Tokenizer.cs
+++ b/Src/IronPython/Compiler/Tokenizer.cs
@@ -218,86 +218,87 @@ namespace IronPython.Compiler {
                 throw new InvalidOperationException("Uninitialized");
             }
 
-            TokenInfo result = new TokenInfo();
             Token token = GetNextToken();
-            result.SourceSpan = new SourceSpan(IndexToLocation(TokenSpan.Start), IndexToLocation(TokenSpan.End));
+            var sourceSpan = new SourceSpan(IndexToLocation(TokenSpan.Start), IndexToLocation(TokenSpan.End));
+            var category = default(TokenCategory);
+            var trigger = default(TokenTriggers);
 
             switch (token.Kind) {
                 case TokenKind.EndOfFile:
-                    result.Category = TokenCategory.EndOfStream;
+                    category = TokenCategory.EndOfStream;
                     break;
 
                 case TokenKind.Comment:
-                    result.Category = TokenCategory.Comment;
+                    category = TokenCategory.Comment;
                     break;
 
                 case TokenKind.Name:
-                    result.Category = TokenCategory.Identifier;
+                    category = TokenCategory.Identifier;
                     break;
 
                 case TokenKind.Error:
                     if (token is IncompleteStringErrorToken) {
-                        result.Category = TokenCategory.StringLiteral;
+                        category = TokenCategory.StringLiteral;
                     } else {
-                        result.Category = TokenCategory.Error;
+                        category = TokenCategory.Error;
                     }
                     break;
 
                 case TokenKind.Constant:
-                    result.Category = (token.Value is string) ? TokenCategory.StringLiteral : TokenCategory.NumericLiteral;
+                    category = (token.Value is string) ? TokenCategory.StringLiteral : TokenCategory.NumericLiteral;
                     break;
 
                 case TokenKind.LeftParenthesis:
-                    result.Category = TokenCategory.Grouping;
-                    result.Trigger = TokenTriggers.MatchBraces | TokenTriggers.ParameterStart;
+                    category = TokenCategory.Grouping;
+                    trigger = TokenTriggers.MatchBraces | TokenTriggers.ParameterStart;
                     break;
 
                 case TokenKind.RightParenthesis:
-                    result.Category = TokenCategory.Grouping;
-                    result.Trigger = TokenTriggers.MatchBraces | TokenTriggers.ParameterEnd;
+                    category = TokenCategory.Grouping;
+                    trigger = TokenTriggers.MatchBraces | TokenTriggers.ParameterEnd;
                     break;
 
                 case TokenKind.LeftBracket:
                 case TokenKind.LeftBrace:
                 case TokenKind.RightBracket:
                 case TokenKind.RightBrace:
-                    result.Category = TokenCategory.Grouping;
-                    result.Trigger = TokenTriggers.MatchBraces;
+                    category = TokenCategory.Grouping;
+                    trigger = TokenTriggers.MatchBraces;
                     break;
 
                 case TokenKind.Colon:
-                    result.Category = TokenCategory.Delimiter;
+                    category = TokenCategory.Delimiter;
                     break;
 
                 case TokenKind.Semicolon:
-                    result.Category = TokenCategory.Delimiter;
+                    category = TokenCategory.Delimiter;
                     break;
 
                 case TokenKind.Comma:
-                    result.Category = TokenCategory.Delimiter;
-                    result.Trigger = TokenTriggers.ParameterNext;
+                    category = TokenCategory.Delimiter;
+                    trigger = TokenTriggers.ParameterNext;
                     break;
 
                 case TokenKind.Dot:
-                    result.Category = TokenCategory.Operator;
-                    result.Trigger = TokenTriggers.MemberSelect;
+                    category = TokenCategory.Operator;
+                    trigger = TokenTriggers.MemberSelect;
                     break;
 
                 case TokenKind.NewLine:
-                    result.Category = TokenCategory.WhiteSpace;
+                    category = TokenCategory.WhiteSpace;
                     break;
 
                 default:
                     if (token.Kind >= TokenKind.FirstKeyword && token.Kind <= TokenKind.LastKeyword) {
-                        result.Category = TokenCategory.Keyword;
+                        category = TokenCategory.Keyword;
                         break;
                     }
 
-                    result.Category = TokenCategory.Operator;
+                    category = TokenCategory.Operator;
                     break;
             }
 
-            return result;
+            return new TokenInfo(sourceSpan, category, trigger);
         }
 
         internal bool TryGetTokenString(int len, out string tokenString) {
@@ -1255,7 +1256,7 @@ namespace IronPython.Compiler {
         /// <summary>
         /// Equality comparer that can compare strings to our current token w/o creating a new string first.
         /// </summary>
-        class TokenEqualityComparer : IEqualityComparer<object> {
+        private class TokenEqualityComparer : IEqualityComparer<object> {
             private readonly Tokenizer _tokenizer;
 
             public TokenEqualityComparer(Tokenizer tokenizer) {
@@ -1610,7 +1611,7 @@ namespace IronPython.Compiler {
         }
 
         [Serializable]
-        class IncompleteString : IEquatable<IncompleteString> {
+        private class IncompleteString : IEquatable<IncompleteString> {
             public readonly bool IsRaw, IsUnicode, IsTripleQuoted, IsSingleTickQuote;
 
             public IncompleteString(bool isSingleTickQuote, bool isRaw, bool isUnicode, bool isTriple) {
@@ -1662,7 +1663,7 @@ namespace IronPython.Compiler {
         }
 
         [Serializable]
-        struct State : IEquatable<State> {
+        private struct State : IEquatable<State> {
             // indentation state
             public int[] Indent;
             public int IndentLevel;

--- a/Src/IronPython/Runtime/BuiltinsDictionaryStorage.cs
+++ b/Src/IronPython/Runtime/BuiltinsDictionaryStorage.cs
@@ -21,7 +21,7 @@ using Microsoft.Scripting.Runtime;
 using IronPython.Modules;
 
 namespace IronPython.Runtime {
-    class BuiltinsDictionaryStorage : ModuleDictionaryStorage {
+    internal class BuiltinsDictionaryStorage : ModuleDictionaryStorage {
         private readonly EventHandler<ModuleChangeEventArgs/*!*/>/*!*/ _change;
         private object _import;
 

--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -347,7 +347,7 @@ namespace IronPython.Runtime
             _mainThreadFunctionStack = PythonOps.GetFunctionStack();
         }
 
-        void ManagerAssemblyLoaded(object sender, AssemblyLoadedEventArgs e) {
+        private void ManagerAssemblyLoaded(object sender, AssemblyLoadedEventArgs e) {
             _topNamespace.LoadAssembly(e.Assembly);
         }
 
@@ -1371,7 +1371,7 @@ namespace IronPython.Runtime
             AppDomain.CurrentDomain.AssemblyResolve += _resolveHolder.AssemblyResolveEvent;
         }
 
-        class AssemblyResolveHolder {
+        private class AssemblyResolveHolder {
             private readonly WeakReference _context;
 
             public AssemblyResolveHolder(PythonContext context) {
@@ -2563,7 +2563,7 @@ namespace IronPython.Runtime
             }
         }
 
-        class AttrKey : IEquatable<AttrKey> {
+        private class AttrKey : IEquatable<AttrKey> {
             private Type _type;
             private string _name;
 
@@ -3960,7 +3960,7 @@ namespace IronPython.Runtime
             }
         }
 
-        class OperationRetTypeKey<T> : IEquatable<OperationRetTypeKey<T>> {
+        private class OperationRetTypeKey<T> : IEquatable<OperationRetTypeKey<T>> {
             public readonly Type ReturnType;
             public readonly T Operation;
 
@@ -4260,7 +4260,7 @@ namespace IronPython.Runtime
     /// List of unary operators which we have sites for to enable fast dispatch that
     /// doesn't collide with other operators.
     /// </summary>
-    enum UnaryOperators {
+    internal enum UnaryOperators {
         Repr,
         Length,
         Hash,
@@ -4269,7 +4269,7 @@ namespace IronPython.Runtime
         Maximum
     }
 
-    enum TernaryOperators {
+    internal enum TernaryOperators {
         SetDescriptor,
         GetDescriptor,
 

--- a/Src/IronPython/Runtime/Types/OldClass.cs
+++ b/Src/IronPython/Runtime/Types/OldClass.cs
@@ -42,7 +42,7 @@ namespace IronPython.Runtime.Types {
     // from built-in types).
 
     [Flags]
-    enum OldClassAttributes {
+    internal enum OldClassAttributes {
         None = 0x00,
         HasFinalizer = 0x01,
         HasSetAttr = 0x02,

--- a/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
+++ b/Src/IronPython/Runtime/Types/PythonTypeInfo.cs
@@ -102,7 +102,7 @@ namespace IronPython.Runtime.Types {
         #region Cached type members
 
         public static class _Object {
-            public new static readonly MethodInfo/*!*/ GetType = typeof(object).GetMethod("GetType");
+            public static new readonly MethodInfo/*!*/ GetType = typeof(object).GetMethod("GetType");
         }
 
         public static class _IPythonObject {
@@ -143,7 +143,7 @@ namespace IronPython.Runtime.Types {
         /// names of members that don't exist.  The base MemberResolver will then verify their existance as well as 
         /// filter duplicates.
         /// </summary>
-        abstract class MemberResolver {
+        private abstract class MemberResolver {
             /// <summary>
             /// Looks up an individual member and returns a MemberGroup with the given members.
             /// </summary>
@@ -183,7 +183,7 @@ namespace IronPython.Runtime.Types {
         /// One off resolver for various special methods which are known by name.  A delegate is provided to provide the actual member which
         /// will be resolved.
         /// </summary>
-        class OneOffResolver : MemberResolver {
+        private class OneOffResolver : MemberResolver {
             private string/*!*/ _name;
             private Func<MemberBinder/*!*/, Type/*!*/, MemberGroup/*!*/>/*!*/ _resolver;
 
@@ -212,7 +212,7 @@ namespace IronPython.Runtime.Types {
         /// <summary>
         /// Standard resolver for looking up .NET members.  Uses reflection to get the members by name.
         /// </summary>
-        class StandardResolver : MemberResolver {
+        private class StandardResolver : MemberResolver {
             public override MemberGroup/*!*/ ResolveMember(MemberBinder/*!*/ binder, MemberRequestKind/*!*/ action, Type/*!*/ type, string/*!*/ name) {
                 if (name == ".ctor" || name == ".cctor") return MemberGroup.EmptyGroup;
 
@@ -267,7 +267,7 @@ namespace IronPython.Runtime.Types {
         /// <summary>
         /// Resolves methods mapped to __eq__ and __ne__ from IStructuralEquatable.Equals
         /// </summary>
-        class EqualityResolver : MemberResolver {
+        private class EqualityResolver : MemberResolver {
             public static readonly EqualityResolver Instance = new EqualityResolver();
 
             private EqualityResolver() { }
@@ -304,7 +304,7 @@ namespace IronPython.Runtime.Types {
         /// 
         /// This should be run after the EqualityResolver.
         /// </summary>
-        class ComparisonResolver : MemberResolver {
+        private class ComparisonResolver : MemberResolver {
             private readonly bool _excludePrimitiveTypes;
             private readonly Type/*!*/ _comparable;
             private readonly Dictionary<string/*!*/, string/*!*/>/*!*/ _helperMap;
@@ -351,7 +351,7 @@ namespace IronPython.Runtime.Types {
         /// <summary>
         /// Resolves methods mapped to __*__ methods automatically from the .NET operator.
         /// </summary>
-        class OperatorResolver : MemberResolver {
+        private class OperatorResolver : MemberResolver {
             public override MemberGroup/*!*/ ResolveMember(MemberBinder/*!*/ binder, MemberRequestKind/*!*/ action, Type/*!*/ type, string/*!*/ name) {
                 if (type.IsSealed() && type.IsAbstract()) {
                     // static types don't have PythonOperationKind
@@ -504,7 +504,7 @@ namespace IronPython.Runtime.Types {
         /// <summary>
         /// Provides bindings to private members when that global option is enabled.
         /// </summary>
-        class PrivateBindingResolver : MemberResolver {
+        private class PrivateBindingResolver : MemberResolver {
             private const BindingFlags _privateFlags = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
 
             public override MemberGroup/*!*/ ResolveMember(MemberBinder/*!*/ binder, MemberRequestKind/*!*/ action, Type/*!*/ type, string/*!*/ name) {
@@ -544,7 +544,7 @@ namespace IronPython.Runtime.Types {
         /// Provides resolutions for protected members that haven't yet been
         /// subclassed by NewTypeMaker.
         /// </summary>
-        class ProtectedMemberResolver : MemberResolver {
+        private class ProtectedMemberResolver : MemberResolver {
             public override MemberGroup/*!*/ ResolveMember(MemberBinder/*!*/ binder, MemberRequestKind/*!*/ action, Type/*!*/ type, string/*!*/ name) {
                 foreach (Type t in binder.GetContributingTypes(type)) {
                     MemberGroup res = new MemberGroup(
@@ -1078,7 +1078,7 @@ namespace IronPython.Runtime.Types {
             return res;
         }
 
-        class DocumentationDescriptor : PythonTypeSlot {
+        private class DocumentationDescriptor : PythonTypeSlot {
             internal override bool TryGetValue(CodeContext context, object instance, PythonType owner, out object value) {
                 if (owner.IsSystemType) {
                     value = PythonTypeOps.GetDocumentation(owner.UnderlyingSystemType);

--- a/Src/IronPythonTest/InheritTest.cs
+++ b/Src/IronPythonTest/InheritTest.cs
@@ -72,7 +72,7 @@ namespace IronPythonTest {
     }
 
     public class BaseClassStaticConstructor {
-        static int value;
+        private static int value;
         static BaseClassStaticConstructor() {
             value = 10;
         }
@@ -327,7 +327,7 @@ namespace IronPythonTest {
 
 
     public abstract class Overriding {
-        string protVal = "Overriding.Protected";
+        private string protVal = "Overriding.Protected";
 
         public virtual object __cmp__(object other) {
             return "Overriding.__cmp__(object)";
@@ -670,7 +670,7 @@ namespace IronPythonTest {
     }
 
     public class UseCReturnTypes {
-        CReturnTypes type;
+        private CReturnTypes type;
         public UseCReturnTypes(CReturnTypes type) { this.type = type; }
 
         public void Use_void() { type.M_void(); }
@@ -724,7 +724,7 @@ namespace IronPythonTest {
     }
 
     public class UseIReturnTypes {
-        IReturnTypes type;
+        private IReturnTypes type;
         public UseIReturnTypes(IReturnTypes type) { this.type = type; }
 
         public void Use_void() { type.M_void(); }
@@ -775,7 +775,7 @@ namespace IronPythonTest {
     }
 
     public class UseAReturnTypes {
-        AReturnTypes type;
+        private AReturnTypes type;
         public UseAReturnTypes(AReturnTypes type) { this.type = type; }
 
         public void Use_void() { type.M_void(); }


### PR DESCRIPTION
Changes `Tokenizer.ReadToken` to use `TokenInfo` constructor so that it can eventually be made `readonly`.