### PR TITLE
[WIP] Attempt to get Mono.Posix working with zip package

### DIFF
--- a/Src/IronPython/Runtime/PythonContext.cs
+++ b/Src/IronPython/Runtime/PythonContext.cs
@@ -287,7 +287,7 @@ namespace IronPython.Runtime
                         path.append(devStdLib);
                     }
 #else
-                    if(!IronPython.Runtime.ClrModule.IsNetCoreApp && Environment.OSVersion.Platform == PlatformID.Unix) {
+                    if(Environment.OSVersion.Platform == PlatformID.Unix) {
                         if(Directory.Exists("/usr/lib/ironpython2.7")) {
                             path.append("/usr/lib/ironpython2.7");
                         }

--- a/Src/IronPythonConsoleAny/IronPythonConsoleAny.csproj
+++ b/Src/IronPythonConsoleAny/IronPythonConsoleAny.csproj
@@ -30,6 +30,9 @@
     <Content Include="ipy.sh">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Mono.Posix.NETStandard.deps.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' OR '$(TargetFramework)' == 'netcoreapp2.1' ">

--- a/Src/IronPythonConsoleAny/Mono.Posix.NETStandard.deps.json
+++ b/Src/IronPythonConsoleAny/Mono.Posix.NETStandard.deps.json
@@ -1,0 +1,122 @@
+{
+  "runtimeTarget": {
+    "name": ".NETCoreApp,Version=v2.0",
+    "signature": "f9b719c533e48bff407d4621c1a86654cca8caa1"
+  },
+  "compilationOptions": {},
+  "targets": {
+    ".NETCoreApp,Version=v2.0": {
+      "Mono.Posix.NETStandard/1.0.0": {
+        "runtimeTargets": {
+          "runtimes/linux-arm/lib/netstandard2.0/Mono.Posix.NETStandard.dll": {
+            "rid": "linux-arm",
+            "assetType": "runtime",
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          },
+          "runtimes/linux-arm64/lib/netstandard2.0/Mono.Posix.NETStandard.dll": {
+            "rid": "linux-arm64",
+            "assetType": "runtime",
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          },
+          "runtimes/linux-armel/lib/netstandard2.0/Mono.Posix.NETStandard.dll": {
+            "rid": "linux-armel",
+            "assetType": "runtime",
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          },
+          "runtimes/linux-x64/lib/netstandard2.0/Mono.Posix.NETStandard.dll": {
+            "rid": "linux-x64",
+            "assetType": "runtime",
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          },
+          "runtimes/linux-x86/lib/netstandard2.0/Mono.Posix.NETStandard.dll": {
+            "rid": "linux-x86",
+            "assetType": "runtime",
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          },
+          "runtimes/osx/lib/netstandard2.0/Mono.Posix.NETStandard.dll": {
+            "rid": "osx",
+            "assetType": "runtime",
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          },
+          "runtimes/win-x64/lib/netstandard2.0/Mono.Posix.NETStandard.dll": {
+            "rid": "win-x64",
+            "assetType": "runtime",
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          },
+          "runtimes/win-x86/lib/netstandard2.0/Mono.Posix.NETStandard.dll": {
+            "rid": "win-x86",
+            "assetType": "runtime",
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.0.0.0"
+          },
+          "runtimes/linux-arm/native/libMonoPosixHelper.so": {
+            "rid": "linux-arm",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/linux-arm64/native/libMonoPosixHelper.so": {
+            "rid": "linux-arm64",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/linux-armel/native/libMonoPosixHelper.so": {
+            "rid": "linux-armel",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/linux-x64/native/libMonoPosixHelper.so": {
+            "rid": "linux-x64",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/linux-x86/native/libMonoPosixHelper.so": {
+            "rid": "linux-x86",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/osx/native/libMonoPosixHelper.dylib": {
+            "rid": "osx",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x64/native/MonoPosixHelper.dll": {
+            "rid": "win-x64",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x64/native/libMonoPosixHelper.dll": {
+            "rid": "win-x64",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x86/native/MonoPosixHelper.dll": {
+            "rid": "win-x86",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x86/native/libMonoPosixHelper.dll": {
+            "rid": "win-x86",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          }
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Mono.Posix.NETStandard/1.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-vSN/L1uaVwKsiLa95bYu2SGkF0iY3xMblTfxc8alSziPuVfJpj3geVqHGAA75J7cZkMuKpFVikz82Lo6y6LLdA==",
+      "path": "mono.posix.netstandard/1.0.0",
+      "hashPath": "mono.posix.netstandard.1.0.0.nupkg.sha512"
+    }
+  }
+}

--- a/Src/IronPythonConsoleAny/ipy.sh
+++ b/Src/IronPythonConsoleAny/ipy.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 BASEDIR=$(dirname $0)
 ABS_PATH=`cd "$BASEDIR"; pwd`
-dotnet $ABS_PATH/ipy.dll $@
+dotnet --additional-deps "$ABS_PATH/Mono.Posix.NETStandard.deps.json" "$ABS_PATH/ipy.dll" $@

--- a/Src/StdLib/Lib/distutils/command/install.py
+++ b/Src/StdLib/Lib/distutils/command/install.py
@@ -41,9 +41,9 @@ else:
 
 INSTALL_SCHEMES = {
     'unix_prefix': {
-        'purelib': '$base/lib/python$py_version_short/site-packages',
-        'platlib': '$platbase/lib/python$py_version_short/site-packages',
-        'headers': '$base/include/python$py_version_short/$dist_name',
+        'purelib': '$base/lib/ironpython$py_version_short/site-packages',
+        'platlib': '$platbase/lib/ironpython$py_version_short/site-packages',
+        'headers': '$base/include/ironpython$py_version_short/$dist_name',
         'scripts': '$base/bin',
         'data'   : '$base',
         },
@@ -57,7 +57,7 @@ INSTALL_SCHEMES = {
     'unix_user': {
         'purelib': '$usersite',
         'platlib': '$usersite',
-        'headers': '$userbase/include/python$py_version_short/$dist_name',
+        'headers': '$userbase/include/ironpython$py_version_short/$dist_name',
         'scripts': '$userbase/bin',
         'data'   : '$userbase',
         },
@@ -79,7 +79,7 @@ INSTALL_SCHEMES = {
     'os2_home': {
         'purelib': '$usersite',
         'platlib': '$usersite',
-        'headers': '$userbase/include/python$py_version_short/$dist_name',
+        'headers': '$userbase/include/ironpython$py_version_short/$dist_name',
         'scripts': '$userbase/bin',
         'data'   : '$userbase',
         },


### PR DESCRIPTION
So the idea is to place the `runtimes` folder of the `Mono.Posix.NETStandard` package in the `netcoreapp2.0` and `netcoreapp2.1` folders of the zip package and then load them up using a deps file.

Maybe this isn't the way to go... Perhaps we should be doing a `dotnet publish` and including the `runtimes` folder as well as `ipy.deps.json` with the application?

@slide The part I haven't figured out it how to get the `runtimes` folder from the nuget package to the staging folder so it can get packaged.

Related to https://github.com/IronLanguages/ironpython2/issues/364