### PR TITLE
Fix incorrect result of set.contain

### DIFF
--- a/Src/IronPython/Runtime/SetStorage.cs
+++ b/Src/IronPython/Runtime/SetStorage.cs
@@ -264,10 +264,12 @@ namespace IronPython.Runtime {
 
                 for (int i = 0; i < buckets.Length; i++) {
                     Bucket bucket = buckets[i];
-                    if (bucket.Item != null && bucket.Item != Removed) {
+                    if (bucket.Item != null) {
                         res._buckets[i].Item = bucket.Item;
                         res._buckets[i].HashCode = bucket.HashCode;
-                        res._count++;
+                        if (bucket.Item != Removed) {
+                            res._count++;
+                        }
                     }
                 }
             }

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -1276,4 +1276,12 @@ class C:
         self.assertEqual((root.tag, root.attrib), ("{default}root", {}))
         self.assertItemsEqual([(child.tag, child.attrib) for child in root], [("{default}child", {}), ("{http://uri}child", {})])
 
+    def test_ipy2_gh519(self):
+        """https://github.com/IronLanguages/ironpython2/issues/519"""
+        x = set(range(8))
+        x.add(16)
+        x.remove(0)
+        self.assertTrue(16 in x)
+        self.assertTrue(16 in set(x))
+
 run_test(__name__)


### PR DESCRIPTION
Fixes #519 .

In certain situations, it is possible to have the following assert
violated:

    for item in things:
        assert item in things

This happens when "null-holes" are found in the bucket table between the
start index (hashCode % buckets.Length) and the actual index where an item
is inserted.

These holes are created during fast copying because buckets marked as
removed are not carried over to the new bucket table