### PR TITLE
Allow using mmap with io.opened file

### DIFF
--- a/Src/IronPython.Modules/mmap.cs
+++ b/Src/IronPython.Modules/mmap.cs
@@ -154,14 +154,17 @@ namespace IronPython.Modules {
                     // Memory-map an actual file
                     _offset = offset;
 
-                    PythonFile file;
                     PythonContext pContext = context.LanguageContext;
-                    if (!pContext.FileManager.TryGetFileFromId(pContext, fileno, out file)) {
+                    if (pContext.FileManager.TryGetFileFromId(pContext, fileno, out PythonFile file)) {
+                        if ((_sourceStream = file._stream as FileStream) == null) {
+                            throw WindowsError(PythonExceptions._WindowsError.ERROR_INVALID_HANDLE);
+                        }
+                    } else if (pContext.FileManager.TryGetObjectFromId(pContext, fileno, out object obj) && obj is PythonIOModule.FileIO fileio) {
+                        if ((_sourceStream = fileio._readStream as FileStream) == null) {
+                            throw WindowsError(PythonExceptions._WindowsError.ERROR_INVALID_HANDLE);
+                        }
+                    } else {
                         throw Error(context, PythonExceptions._WindowsError.ERROR_INVALID_BLOCK, "Bad file descriptor");
-                    }
-
-                    if ((_sourceStream = file._stream as FileStream) == null) {
-                        throw WindowsError(PythonExceptions._WindowsError.ERROR_INVALID_HANDLE);
                     }
 
                     if (_fileAccess == MemoryMappedFileAccess.ReadWrite && !_sourceStream.CanWrite) {

--- a/Tests/test_regressions.py
+++ b/Tests/test_regressions.py
@@ -1294,4 +1294,24 @@ class C:
         c.execute("INSERT INTO test (test) VALUES (x'');")
         self.assertEqual(len(c.execute("SELECT * FROM test;").fetchone()[0]), 0)
 
+    def test_main_gh1081(self):
+        """https://github.com/IronLanguages/main/issues/1081"""
+        import io
+        import mmap
+
+        test_file_name = os.path.join(self.temporary_dir, "test_main_gh1081.bin")
+
+        with open(test_file_name, "wb") as f:
+            f.write(bytearray(range(256)))
+
+        try:
+            with io.open(test_file_name, "rb") as f:
+                mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
+                try:
+                    self.assertEqual(mm[:], bytearray(range(256)))
+                finally:
+                    mm.close()
+        finally:
+            os.remove(test_file_name)
+
 run_test(__name__)


### PR DESCRIPTION
Resolves https://github.com/IronLanguages/main/issues/1081

This is basically more duct tape on the file manager in order to get mmap to work with io.open.