### PR TITLE
 Made PythonVariable class public

### DIFF
--- a/Src/IronPython/Compiler/Ast/PythonVariable.cs
+++ b/Src/IronPython/Compiler/Ast/PythonVariable.cs
@@ -27,7 +27,7 @@ using IronPython.Runtime;
 namespace IronPython.Compiler.Ast {
     using Ast = MSAst.Expression;
 
-    internal class PythonVariable {
+    public class PythonVariable {
         private readonly string _name;
         private readonly ScopeStatement/*!*/ _scope;
         private VariableKind _kind;    // the type of variable, 

--- a/Src/IronPython/Compiler/Ast/VariableKind.cs
+++ b/Src/IronPython/Compiler/Ast/VariableKind.cs
@@ -15,7 +15,7 @@
 
 namespace IronPython.Compiler.Ast {
 
-    internal enum VariableKind {
+    public enum VariableKind {
 
         /// <summary>
         /// Local variable.

--- a/Src/IronPython/Modules/_ast.cs
+++ b/Src/IronPython/Modules/_ast.cs
@@ -86,12 +86,13 @@ namespace IronPython.Modules
         }
 
         internal static AST BuildAst(CodeContext context, SourceUnit sourceUnit, PythonCompilerOptions opts, string mode) {
-            Parser parser = Parser.CreateParser(
+            using (Parser parser = Parser.CreateParser(
                 new CompilerContext(sourceUnit, opts, ThrowingErrorSink.Default),
-                (PythonOptions)context.LanguageContext.Options);
+                (PythonOptions)context.LanguageContext.Options)) {
 
-            PythonAst ast = parser.ParseFile(true);
-            return ConvertToAST(ast, mode);
+                PythonAst ast = parser.ParseFile(true);
+                return ConvertToAST(ast, mode);
+            }
         }
 
         private static mod ConvertToAST(PythonAst pythonAst, string kind) {


### PR DESCRIPTION
I have an application that makes extensive use of PythonAst to create auto-completion lists. It would be very beneficial to have IronPython.Compiler.Ast.PythonVariable class as public, otherwise it is troublesome parsing AST structure.