### PR TITLE
Add PythonModuleAttribute overload

### DIFF
--- a/Src/IronPython/Runtime/PythonModuleAttribute.cs
+++ b/Src/IronPython/Runtime/PythonModuleAttribute.cs
@@ -17,6 +17,14 @@ namespace IronPython.Runtime {
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
     public sealed class PythonModuleAttribute : PlatformsAttribute {
+        // this overload is to allow binding redirects to assemblies using over versions of ipy (e.g. NumpyDotNet.dll)
+        public PythonModuleAttribute(string/*!*/ name, Type/*!*/ type) {
+            ContractUtils.RequiresNotNull(name, nameof(name));
+            ContractUtils.RequiresNotNull(type, nameof(type));
+
+            Name = name;
+            Type = type;
+        }
 
         /// <summary>
         /// Creates a new PythonModuleAttribute that can be used to specify a built-in module that exists


### PR DESCRIPTION
Related to https://github.com/IronLanguages/ironpython2/issues/587.

This allows the numpy (for .NET) egg (at http://code.enthought.com/.iron/eggs/index.html) to import with ipy.

Note that I think the egg is 32-bit so it needs to run against ipy32. Also, needs binding redirects:
```xml
<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
    <dependentAssembly>
        <assemblyIdentity name="IronPython" publicKeyToken="7f709c5b713576e1" culture="neutral" />
        <bindingRedirect oldVersion="2.7.0.40" newVersion="2.7.10.0" />
    </dependentAssembly>
    <dependentAssembly>
        <assemblyIdentity name="Microsoft.Scripting" publicKeyToken="7f709c5b713576e1" culture="neutral" />
        <bindingRedirect oldVersion="1.1.0.20" newVersion="1.2.2.0" />
    </dependentAssembly>
    <dependentAssembly>
        <assemblyIdentity name="Microsoft.Dynamic" publicKeyToken="7f709c5b713576e1" culture="neutral" />
        <bindingRedirect oldVersion="1.1.0.20" newVersion="1.2.2.0" />
    </dependentAssembly>
</assemblyBinding>
```

Related links: 
- http://blog.enthought.com/python/scipy-for-net
- https://stackoverflow.com/questions/29397540/how-to-install-numpy-and-scipy-for-ironpython27-old-method-doenst-work
- https://github.com/enthought/numpy-refactor
