### PR TITLE
Use py3 compatible syntax in tests

### DIFF
--- a/Tests/modules/misc/test__random.py
+++ b/Tests/modules/misc/test__random.py
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-
 import _random
 import unittest
 from iptest import run_test

--- a/Tests/modules/misc/test__sha256.py
+++ b/Tests/modules/misc/test__sha256.py
@@ -2,12 +2,9 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-
 '''
 This tests what CPythons test_sha.py does not hit.
 '''
-
-from __future__ import absolute_import
 
 import _sha256
 import unittest
@@ -24,7 +21,7 @@ class _Sha256Test(unittest.TestCase):
         self.assertTrue("sha224" in dir (_sha256))
         self.assertTrue("sha256" in dir(_sha256))
         #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21920
-        self.assertEqual(len(dir(_sha256)), 5)#, "There should only be five attributes in the _sha256 module!")
+        self.assertEqual(len(dir(_sha256)), 5, "there should be 5 attributes in the _sha256 module")
 
     def test_sha256_sanity(self):
         x = _sha256.sha256()
@@ -39,11 +36,11 @@ class _Sha256Test(unittest.TestCase):
         x.update("abc")
         self.assertEqual(x.hexdigest(),
                 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
-        
+
         x_copy = x.copy()
         self.assertTrue(x!=x_copy)
         self.assertEqual(x.hexdigest(), x_copy.hexdigest())
-        
+
     def test_sha224_sanity(self):
         x = _sha256.sha224()
         self.assertEqual(x.block_size, 64)
@@ -57,10 +54,9 @@ class _Sha256Test(unittest.TestCase):
         x.update("abc")
         self.assertEqual(x.hexdigest(),
                 '23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7')
-        
+
         x_copy = x.copy()
         self.assertTrue(x!=x_copy)
         self.assertEqual(x.hexdigest(), x_copy.hexdigest())
-
 
 run_test(__name__)

--- a/Tests/modules/misc/test__sha512.py
+++ b/Tests/modules/misc/test__sha512.py
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-
 '''
 This tests what CPythons test_sha.py does not hit.
 '''
@@ -12,7 +11,6 @@ import unittest
 
 from iptest import is_cli, run_test
 
-
 class _Sha512Test(unittest.TestCase):
     def test_sanity(self):
         self.assertTrue("__doc__" in dir(_sha512))
@@ -21,7 +19,7 @@ class _Sha512Test(unittest.TestCase):
         self.assertTrue("__name__" in dir(_sha512))
         self.assertTrue("sha384" in dir (_sha512))
         self.assertTrue("sha512" in dir(_sha512))
-        self.assertEqual(len(dir(_sha512)), 5)#, "There should only be five attributes in the _sha512 module!")
+        self.assertEqual(len(dir(_sha512)), 5, "there should be 5 attributes in the _sha512 module")
 
     def test_sha512_sanity(self):
         x = _sha512.sha512()
@@ -36,11 +34,11 @@ class _Sha512Test(unittest.TestCase):
         x.update("abc")
         self.assertEqual(x.hexdigest(),
                 'ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f')
-        
+
         x_copy = x.copy()
         self.assertTrue(x!=x_copy)
         self.assertEqual(x.hexdigest(), x_copy.hexdigest())
-        
+
     def test_sha384_sanity(self):
         x = _sha512.sha384()
         self.assertEqual(x.block_size, 128)
@@ -54,7 +52,7 @@ class _Sha512Test(unittest.TestCase):
         x.update("abc")
         self.assertEqual(x.hexdigest(),
                 'cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7')
-        
+
         x_copy = x.copy()
         self.assertTrue(x!=x_copy)
         self.assertEqual(x.hexdigest(), x_copy.hexdigest())

--- a/Tests/modules/misc/test__warnings.py
+++ b/Tests/modules/misc/test__warnings.py
@@ -12,16 +12,16 @@ from iptest import IronPythonTestCase, run_test, stderr_trapper as stderr_trappe
 
 #--GLOBALS---------------------------------------------------------------------
 EXPECTED = [] # expected output (ignoring filename, lineno, and line)
-WARN_TYPES = [Warning, UserWarning, PendingDeprecationWarning, SyntaxWarning, 
-              RuntimeWarning, FutureWarning, ImportWarning, UnicodeWarning, 
+WARN_TYPES = [Warning, UserWarning, PendingDeprecationWarning, SyntaxWarning,
+              RuntimeWarning, FutureWarning, ImportWarning, UnicodeWarning,
               BytesWarning]
 
 def cleanup():
     '''Clean up after possible incomplete test runs.'''
     global EXPECTED
     EXPECTED = []
-    
-    
+
+
 def expect(warn_type, message):
     '''Helper for test output'''
     for filter in _warnings.filters:
@@ -34,7 +34,7 @@ class _WarningsTest(IronPythonTestCase):
     #TODO: @skip("multiple_execute")
     def test_sanity(self):
         global EXPECTED
-        try:    
+        try:
             with stderr_trapper() as output:
                 # generate test output
                 _warnings.warn("Warning Message!")
@@ -52,20 +52,20 @@ class _WarningsTest(IronPythonTestCase):
                     expect(warn_type, "Explicit Warning!")
                     _warnings.warn_explicit("Explicit Warning!", warn_type, "test_python26.py", 78, "module.py")
                     expect(warn_type, "Explicit Warning!")
-        
+
             temp_messages = output.messages
-            
+
             #No point in going further if the number of lines is not what we expect
             nlines = len([x for x in temp_messages if not x.startswith("  ")])
             self.assertEqual(nlines, len(EXPECTED))
-            
+
             # match lines
             for line in temp_messages:
                 if line.startswith("  "):
                     continue
                 temp = EXPECTED.pop(0).rstrip()
                 self.assertTrue(line.endswith(temp), str(line) + " does not end with " + temp)
-        
+
         finally:
             # remove generated files
             cleanup()
@@ -77,19 +77,18 @@ class _WarningsTest(IronPythonTestCase):
 
 
     def test_default_action(self):
-        print "TODO"
-    
-    def test_filters(self):
-        print "TODO"
-    
-    def test_once_registry(self):
-        print "TODO"
-    
-    def test_warn(self):
-        print "TODO"
-    
-    def test_warn_explicit(self):
-        print "TODO"
+        print("TODO")
 
+    def test_filters(self):
+        print("TODO")
+
+    def test_once_registry(self):
+        print("TODO")
+
+    def test_warn(self):
+        print("TODO")
+
+    def test_warn_explicit(self):
+        print("TODO")
 
 run_test(__name__)

--- a/Tests/modules/misc/test_ctypes.py
+++ b/Tests/modules/misc/test_ctypes.py
@@ -1,17 +1,9 @@
-#####################################################################################
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
 #
-#  Copyright (c) Pawel Jasinski. All rights reserved.
+# Copyright (c) Pawel Jasinski
 #
-# This source code is subject to terms and conditions of the Apache License, Version 2.0. A
-# copy of the license can be found in the License.html file at the root of this distribution. If
-# you cannot locate the  Apache License, Version 2.0, please send an email to
-# ironpy@microsoft.com. By using this source code in any fashion, you are agreeing to be bound
-# by the terms of the Apache License, Version 2.0.
-#
-# You must not remove this notice, or any other, from this software.
-#
-#
-#####################################################################################
 
 import unittest
 
@@ -43,9 +35,8 @@ class CtypesTest(unittest.TestCase):
 
     @unittest.skipIf(is_posix, 'Windows specific test')
     def test_gh951(self):
-        from ctypes import *
         try:
-            res = cast(windll.kernel32.GetCurrentProcess, c_void_p)
+            res = ctypes.cast(ctypes.windll.kernel32.GetCurrentProcess, ctypes.c_void_p)
             if not isinstance(res, ctypes.c_void_p):
                 self.fail("c_void_p expected in test_cfuncptr")
         except Exception as ex:
@@ -53,4 +44,3 @@ class CtypesTest(unittest.TestCase):
 
 
 run_test(__name__)
-

--- a/Tests/modules/misc/test_datetime.py
+++ b/Tests/modules/misc/test_datetime.py
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-
 ##
 ## Test the datetime module
 ##
@@ -15,7 +14,7 @@ from iptest import IronPythonTestCase, is_cli, run_test, skipUnlessIronPython
 
 class mytzinfo(datetime.tzinfo):
     def __repr__(self): return 'hello'
-    def __eq__(self, other): 
+    def __eq__(self, other):
         return type(other) == type(self)
 
 class DatetimeTest(IronPythonTestCase):
@@ -30,12 +29,12 @@ class DatetimeTest(IronPythonTestCase):
         datetime.date(1,1,1)
         datetime.date(9999, 12, 31)
         datetime.date(2004, 2, 29)
-        
+
         self.assertRaises(ValueError, datetime.date, 2005, 4,31)
         self.assertRaises(ValueError, datetime.date, 2005, 3,32)
         self.assertRaises(ValueError, datetime.datetime, 2006, 2, 29)
         self.assertRaises(ValueError, datetime.datetime, 2006, 9, 31)
-        
+
         self.assertRaises(ValueError, datetime.date, 0, 1, 1)
         self.assertRaises(ValueError, datetime.date, 1, 0, 1)
         self.assertRaises(ValueError, datetime.date, 1, 1, 0)
@@ -50,7 +49,7 @@ class DatetimeTest(IronPythonTestCase):
         self.assertRaises(ValueError, datetime.date, 9999, 12, 32)
         self.assertRaises(ValueError, datetime.date, 10000, 13, 32)
         self.assertRaises(ValueError, datetime.date, 100000, 130, 320)
-        
+
         #add
         x = datetime.date(2005, 3, 22) + datetime.timedelta(1)
         self.assertEqual(x.year, 2005)
@@ -70,7 +69,7 @@ class DatetimeTest(IronPythonTestCase):
         self.assertEqual(x.year, 2005)
         self.assertEqual(x.month, 3)
         self.assertEqual(x.day, 22)
-        
+
         #subtract
         x = datetime.date(2005, 3, 22) - datetime.timedelta(1)
         self.assertEqual(x.year, 2005)
@@ -80,7 +79,7 @@ class DatetimeTest(IronPythonTestCase):
         self.assertEqual(x.year, 2005)
         self.assertEqual(x.month, 3)
         self.assertEqual(x.day, 22)
-        
+
         #equality
         x = datetime.date(2005, 3, 22)
         y = x
@@ -88,73 +87,73 @@ class DatetimeTest(IronPythonTestCase):
         y = datetime.date(2005, 3, 23)
         self.assertTrue(not(x==y))
         self.assertTrue(x==datetime.date(2005, 3, 22))
-        
+
         #inequality
         x = datetime.date(2005, 3, 22)
         y = None
         self.assertTrue(x!=y)
         y = datetime.date(2005, 3, 23)
         self.assertTrue(x!=y)
-        
+
         #ge
         self.assertTrue(datetime.date(2005, 3, 22) >= datetime.date(2005, 3, 22))
         self.assertTrue(datetime.date(2005, 3, 23) >= datetime.date(2005, 3, 22))
         self.assertTrue(datetime.date(2005, 3, 24) >= datetime.date(2005, 3, 22))
         self.assertTrue(not (datetime.date(2005, 3, 21) >= datetime.date(2005, 3, 22)))
         self.assertTrue(not (datetime.date(2005, 3, 20) >= datetime.date(2005, 3, 22)))
-        
+
         #le
         self.assertTrue(datetime.date(2005, 3, 22) <= datetime.date(2005, 3, 22))
         self.assertTrue(datetime.date(2005, 3, 22) <= datetime.date(2005, 3, 23))
         self.assertTrue(datetime.date(2005, 3, 22) <= datetime.date(2005, 3, 24))
         self.assertTrue(not (datetime.date(2005, 3, 22) <= datetime.date(2005, 3, 21)))
         self.assertTrue(not (datetime.date(2005, 3, 22) <= datetime.date(2005, 3, 20)))
-        
+
         #gt
         self.assertTrue(not (datetime.date(2005, 3, 22) > datetime.date(2005, 3, 22)))
         self.assertTrue(datetime.date(2005, 3, 23) > datetime.date(2005, 3, 22))
         self.assertTrue(datetime.date(2005, 3, 24) > datetime.date(2005, 3, 22))
         self.assertTrue(not (datetime.date(2005, 3, 21) > datetime.date(2005, 3, 22)))
         self.assertTrue(not (datetime.date(2005, 3, 20) > datetime.date(2005, 3, 22)))
-        
+
         #lt
         self.assertTrue(not(datetime.date(2005, 3, 22) < datetime.date(2005, 3, 22)))
         self.assertTrue(datetime.date(2005, 3, 22) < datetime.date(2005, 3, 23))
         self.assertTrue(datetime.date(2005, 3, 22) < datetime.date(2005, 3, 24))
         self.assertTrue(not (datetime.date(2005, 3, 22) < datetime.date(2005, 3, 21)))
         self.assertTrue(not (datetime.date(2005, 3, 22) < datetime.date(2005, 3, 20)))
-        
+
         #hash
         x = datetime.date(2005, 3, 22)
         self.assertTrue(x.__hash__()!=None)
-        
+
         #reduce
         x = datetime.date(2005, 3, 22)
         self.assertTrue(x.__reduce__()[0] == datetime.date)
         self.assertEqual(type(x.__reduce__()[1]), tuple)
-        
+
         #repr
         self.assertEqual(repr(datetime.date(2005, 3, 22)), 'datetime.date(2005, 3, 22)')
-        
+
         #str
         self.assertEqual(str(datetime.date(2005, 3, 22)), '2005-03-22')
-        
+
         #ctime
         self.assertEqual(datetime.date(2005, 3, 22).ctime(), 'Tue Mar 22 00:00:00 2005')
-        
+
         #isocalendar
         x = datetime.date(2005, 3, 22).isocalendar()
         self.assertEqual(x[0], 2005)
         self.assertEqual(x[1], 12)
         self.assertEqual(x[2], 2)
-        
+
         #isoformat
         x = datetime.date(2005, 3, 22).isoformat()
         self.assertEqual(x, "2005-03-22")
-        
+
         #isoweekday
         self.assertEqual(datetime.date(2005, 3, 22).isoweekday(), 2)
-        
+
         #replace
         x = datetime.date(2005, 3, 22)
         y = datetime.date(2005, 3, 22)
@@ -170,72 +169,72 @@ class DatetimeTest(IronPythonTestCase):
         z = x.replace(day=25)
         self.assertEqual(y, x)
         self.assertEqual(z.day, 25)
-        
+
         z = x.replace(year=1000, month=5)
         self.assertEqual(y, x)
         self.assertEqual(z.year, 1000)
         self.assertEqual(z.month, 5)
-        
+
         z = x.replace(year=1000, day=25)
         self.assertEqual(y, x)
         self.assertEqual(z.year, 1000)
         self.assertEqual(z.day, 25)
-        
+
         z = x.replace(day=25, month=5)
         self.assertEqual(y, x)
         self.assertEqual(z.day, 25)
         self.assertEqual(z.month, 5)
-        
+
         z = x.replace(day=25, month=5, year=1000)
         self.assertEqual(y, x)
         self.assertEqual(z.day, 25)
         self.assertEqual(z.month, 5)
         self.assertEqual(z.year, 1000)
-        
+
         #strftime
         self.assertEqual(x.strftime("%y-%a-%b"), "05-Tue-Mar")
         self.assertEqual(x.strftime("%Y-%A-%B"), "2005-Tuesday-March")
         self.assertEqual(x.strftime("%Y%m%d"), '20050322')
-        
+
         #timetuple
         self.assertEqual(datetime.date(2005, 3, 22).timetuple(), (2005, 3, 22, 0, 0, 0, 1, 81, -1))
-        
+
         #toordinal
         self.assertEqual(datetime.date(2005, 3, 22).toordinal(), 732027)
 
         #weekday
         self.assertEqual(datetime.date(2005, 3, 22).weekday(), 1)
-        
+
         #fromordinal
         x = datetime.date.fromordinal(1234567)
         self.assertEqual(x.year, 3381)
         self.assertEqual(x.month, 2)
         self.assertEqual(x.day, 16)
-        
+
         #fromtimestamp
         x = datetime.date.fromtimestamp(1000000000.0)
         self.assertEqual(x.year, 2001)
         self.assertEqual(x.month, 9)
         self.assertTrue(x.day == 8 or x.day == 9) # depends on the time zone
-        
+
         #max
         x = datetime.date.max
         self.assertEqual(x.year, 9999)
         self.assertEqual(x.month, 12)
         self.assertEqual(x.day, 31)
-        
+
         #min
         x = datetime.date.min
         self.assertEqual(x.year, 1)
         self.assertEqual(x.month, 1)
         self.assertEqual(x.day, 1)
-        
+
         #resolution
         self.assertEqual(repr(datetime.date.resolution), 'datetime.timedelta(1)')
-        
+
         #today
         datetime.date.today()
-        
+
         #boolean op
         self.assertTrue(datetime.date(2005, 3, 22))
 
@@ -248,31 +247,31 @@ class DatetimeTest(IronPythonTestCase):
         self.assertEqual(x.minute, 28)
         self.assertEqual(x.second, 3)
         self.assertEqual(x.microsecond, 99)
-        
+
         datetime.datetime(2006,4,11)
         datetime.datetime(2006,4,11,2)
         datetime.datetime(2006,4,11,2,28)
         datetime.datetime(2006,4,11,2,28,3)
         datetime.datetime(2006,4,11,2,28,3,99)
         datetime.datetime(2006,4,11,2,28,3,99, None)
-        
+
         datetime.datetime(2006,4,11,hour=2)
         datetime.datetime(2006,4,11,hour=2,minute=28)
         datetime.datetime(2006,4,11,hour=2,minute=28,second=3)
         datetime.datetime(2006,4,11,hour=2,minute=28,second=3, microsecond=99)
         datetime.datetime(2006,4,11,hour=2,minute=28,second=3, microsecond=99, tzinfo=None)
-        
+
         datetime.datetime(1, 1, 1, 0, 0, 0, 0) #min
         datetime.datetime(9999, 12, 31, 23, 59, 59, 999999) #max
         datetime.datetime(2004, 2, 29, 16, 20, 22, 262000) #leapyear
-        
+
         self.assertRaises(ValueError, datetime.datetime, 2006, 2, 29, 16, 20, 22, 262000) #bad leapyear
         self.assertRaises(ValueError, datetime.datetime, 2006, 9, 31, 16, 20, 22, 262000) #bad number of days
-        
+
         self.assertRaises(ValueError, datetime.datetime, 0, 1, 1, 0, 0, 0, 0)
         self.assertRaises(ValueError, datetime.datetime, 1, 0, 1, 0, 0, 0, 0)
         self.assertRaises(ValueError, datetime.datetime, 1, 1, 0, 0, 0, 0, 0)
-        
+
         self.assertRaises(ValueError, datetime.datetime, -1, 1, 1, 0, 0, 0, 0)
         self.assertRaises(ValueError, datetime.datetime, 1, -1, 1, 0, 0, 0, 0)
         self.assertRaises(ValueError, datetime.datetime, 1, 1, -1, 0, 0, 0, 0)
@@ -292,7 +291,7 @@ class DatetimeTest(IronPythonTestCase):
         self.assertRaises(ValueError, datetime.datetime, 10000, 13, 32, 24, 60, 60, 1000000)
         self.assertRaises(ValueError, datetime.datetime, 100000, 130, 320, 240, 600, 600, 10000000)
         self.assertRaises(TypeError,  datetime.datetime, 2006, 4, 11, 2, 28, 3, 99, 1)
-        
+
         #--------------------------------------------------------------------------
         #--Test subtraction datetime
         test_data = { ((2006, 9, 29, 15, 37, 28, 686000), (2006, 9, 29, 15, 37, 28, 686000)) : ((0, 0, 0),(0, 0, 0)),
@@ -309,18 +308,18 @@ class DatetimeTest(IronPythonTestCase):
         for key, (value0, value1) in test_data.iteritems():
             dt1 = datetime.datetime(*key[1])
             dt0 = datetime.datetime(*key[0])
-            
+
             x = dt1 - dt0
             self.assertEqual(x.days, value0[0])
             self.assertEqual(x.seconds, value0[1])
             self.assertEqual(x.microseconds, value0[2])
-            
+
             y = dt0 - dt1
             self.assertEqual(y.days, value1[0])
             self.assertEqual(y.seconds, value1[1])
             self.assertEqual(y.microseconds, value1[2])
-            
-            
+
+
         #--------------------------------------------------------------------------
         #--Test subtraction - timedelta
         test_data = { ((2006, 9, 29, 15, 37, 28, 686000), (0, 0, 0)) : (2006, 9, 29, 15, 37, 28, 686000),
@@ -328,18 +327,18 @@ class DatetimeTest(IronPythonTestCase):
                     ((2006, 9, 29, 15, 37, 28, 686000), (0, 1, 0)) : (2006, 9, 29, 15, 37, 27, 686000),
                     ((2006, 9, 29, 15, 37, 28, 686000), (0, 0, 1)) : (2006, 9, 29, 15, 37, 28, 685999),
                     ((2006, 9, 29, 15, 37, 28, 686000), (1, 1, 1)) : (2006, 9, 28, 15, 37, 27, 685999),
-                    
+
                     ((2006, 9, 29, 15, 37, 28, 686000), (-1, 0, 0)) : (2006, 9, 30, 15, 37, 28, 686000),
                     ((2006, 9, 29, 15, 37, 28, 686000), (0, -1, 0)) : (2006, 9, 29, 15, 37, 29, 686000),
                     ((2006, 9, 29, 15, 37, 28, 686000), (0, 0, -1)) : (2006, 9, 29, 15, 37, 28, 686001),
                     ((2006, 9, 29, 15, 37, 28, 686000), (-1, -1, -1)) : (2006, 9, 30, 15, 37, 29, 686001),
-                    
+
                     ((9999, 12, 31, 23, 59, 59, 999999), (1, 1, 1)) : (9999, 12, 30, 23, 59, 58, 999998),
                     ((9999, 12, 31, 23, 59, 59, 999999), (9999*365, 0, 0)) : (7, 8, 21, 23, 59, 59, 999999),
                     ((9999, 12, 31, 23, 59, 59, 999999), (0, 0, 0)) : (9999, 12, 31, 23, 59, 59, 999999),
                     }
         for (dt1, td0), value in test_data.iteritems():
-            
+
             x = datetime.datetime(*dt1) - datetime.timedelta(*td0)
             self.assertEqual(x.year,value[0])
             self.assertEqual(x.month, value[1])
@@ -348,8 +347,8 @@ class DatetimeTest(IronPythonTestCase):
             self.assertEqual(x.minute, value[4])
             self.assertEqual(x.second, value[5])
             self.assertEqual(x.microsecond, value[6])
-        
-        
+
+
         #--------------------------------------------------------------------------
         #--Test addition
         test_data = { ((2006, 9, 29, 15, 37, 28, 686000), (0, 0, 0)) : (2006, 9, 29, 15, 37, 28, 686000),
@@ -357,18 +356,18 @@ class DatetimeTest(IronPythonTestCase):
                     ((2006, 9, 29, 15, 37, 28, 686000), (0, 1, 0)) : (2006, 9, 29, 15, 37, 29, 686000),
                     ((2006, 9, 29, 15, 37, 28, 686000), (0, 0, 1)) : (2006, 9, 29, 15, 37, 28, 686001),
                     ((2006, 9, 29, 15, 37, 28, 686000), (1, 1, 1)) : (2006, 9, 30, 15, 37, 29, 686001),
-                    
+
                     ((2006, 9, 29, 15, 37, 28, 686000), (-1, 0, 0)) : (2006, 9, 28, 15, 37, 28, 686000),
                     ((2006, 9, 29, 15, 37, 28, 686000), (0, -1, 0)) : (2006, 9, 29, 15, 37, 27, 686000),
                     ((2006, 9, 29, 15, 37, 28, 686000), (0, 0, -1)) : (2006, 9, 29, 15, 37, 28, 685999),
                     ((2006, 9, 29, 15, 37, 28, 686000), (-1, -1, -1)) : (2006, 9, 28, 15, 37, 27, 685999),
-        
+
                     ((9999, 12, 31, 23, 59, 59, 999999), (-1, -1, -1)) : (9999, 12, 30, 23, 59, 58, 999998),
                     ((9999, 12, 31, 23, 59, 59, 999999), (-9999*365, 0, 0)) : (7, 8, 21, 23, 59, 59, 999999),
                     ((9999, 12, 31, 23, 59, 59, 999999), (0, 0, 0)) : (9999, 12, 31, 23, 59, 59, 999999),
                     }
         for (dt1, td0), value in test_data.iteritems():
-            
+
             x = datetime.datetime(*dt1) + datetime.timedelta(*td0)
             self.assertEqual(x.year,value[0])
             self.assertEqual(x.month, value[1])
@@ -377,7 +376,7 @@ class DatetimeTest(IronPythonTestCase):
             self.assertEqual(x.minute, value[4])
             self.assertEqual(x.second, value[5])
             self.assertEqual(x.microsecond, value[6])
-            
+
             #CodePlex Work Item 4861
             x = datetime.timedelta(*td0) + datetime.datetime(*dt1)
             self.assertEqual(x.year,value[0])
@@ -387,15 +386,15 @@ class DatetimeTest(IronPythonTestCase):
             self.assertEqual(x.minute, value[4])
             self.assertEqual(x.second, value[5])
             self.assertEqual(x.microsecond, value[6])
-        
+
         #--------------------------------------------------------------------------
-        
+
         #today
         t0 = datetime.datetime.today()
         t1 = datetime.datetime.today()
         self.assertEqual(type(t0), datetime.datetime)
         self.assertTrue(t0<=t1)
-        
+
         #now
         from time import sleep
         t0 = datetime.datetime.now()
@@ -404,14 +403,14 @@ class DatetimeTest(IronPythonTestCase):
         self.assertEqual(type(t0), datetime.datetime)
         self.assertTrue(t1>t0)
         datetime.datetime.now(None)
-        
+
         #now
         t0 = datetime.datetime.utcnow()
         sleep(1)
         t1 = datetime.datetime.utcnow()
         self.assertEqual(type(t0), datetime.datetime)
         self.assertTrue(t1>t0)
-        
+
         #fromtimestamp
         #Merlin Work Item 148717
         x = datetime.datetime.fromtimestamp(1000000000.0)
@@ -421,7 +420,7 @@ class DatetimeTest(IronPythonTestCase):
         # skip x.hours since it depends on the time zone
         self.assertEqual(x.minute, 46)
         self.assertEqual(x.second, 40)
-        
+
         x = datetime.datetime.fromtimestamp(1000000000)
         self.assertEqual(x.year, 2001)
         self.assertEqual(x.month, 9)
@@ -429,13 +428,13 @@ class DatetimeTest(IronPythonTestCase):
         # skip x.hours since it depends on the time zone
         self.assertEqual(x.minute, 46)
         self.assertEqual(x.second, 40)
-        
+
         #fromordinal
         x = datetime.datetime.fromordinal(1234567)
         self.assertEqual(x.year, 3381)
         self.assertEqual(x.month, 2)
         self.assertEqual(x.day, 16)
-        
+
         #fromtimestamp
         x = datetime.datetime.utcfromtimestamp(1000000000.0)
         self.assertEqual(x.year, 2001)
@@ -444,14 +443,14 @@ class DatetimeTest(IronPythonTestCase):
         self.assertEqual(x.hour, 1)
         self.assertEqual(x.minute, 46)
         self.assertEqual(x.second, 40)
-        
+
         #combine
         x = datetime.datetime.combine(datetime.date(2005, 3, 22), datetime.time(2,28,3,99))
         y = datetime.datetime(2005, 3, 22, 2, 28, 3, 99)
         self.assertEqual(x, y)
-        
+
         #strptime - new for Python 2.5. No need to test
-        
+
         #min
         x = datetime.datetime.min
         self.assertEqual(x.year, datetime.MINYEAR)
@@ -464,7 +463,7 @@ class DatetimeTest(IronPythonTestCase):
         #CodePlex Work Item 4863
         y = datetime.datetime(datetime.MINYEAR, 1, 1)
         self.assertEqual(x, y)
-        
+
         #max
         #CodePlex Work Item 4864
         x = datetime.datetime.max
@@ -478,14 +477,14 @@ class DatetimeTest(IronPythonTestCase):
         #CodePlex Work Item 4865
         y = datetime.datetime(datetime.MAXYEAR, 12, 31, 23, 59, 59, 999999, None)
         self.assertEqual(x, y)
-        
+
         #resolution
         #CodePlex Work Item 4866
         x = datetime.datetime.resolution
         self.assertEqual(x.days, 0)
         self.assertEqual(x.seconds, 0)
         self.assertEqual(x.microseconds, 1)
-        
+
         #equality
         x = datetime.datetime(2005, 3, 22)
         y = x
@@ -493,26 +492,26 @@ class DatetimeTest(IronPythonTestCase):
         y = datetime.datetime(2005, 3, 23)
         self.assertTrue(not(x==y))
         self.assertTrue(x==datetime.datetime(2005, 3, 22))
-        
+
         #inequality
         x = datetime.datetime(2005, 3, 22)
         y = None
         self.assertTrue(x!=y)
         y = datetime.datetime(2005, 3, 23)
         self.assertTrue(x!=y)
-        
+
         #ge/le/gt/lt/eq/ne
         #CodePlex Work Item 4860
         #x_args = [2006, 9, 29, 15, 37, 28, 686000]
         x_args = [2006, 9, 29, 15, 37, 28]
         x = datetime.datetime(*x_args)
         for i in range(len(x_args)):
-            
+
             y_args = x_args[0:]
             y_args [i] = y_args[i]+1
             y = datetime.datetime(*y_args)
             x_copy = datetime.datetime(*x_args)
-            
+
             self.assertTrue(y>=x)
             self.assertTrue(x<=y)
             self.assertTrue(x<y)
@@ -521,11 +520,11 @@ class DatetimeTest(IronPythonTestCase):
             self.assertTrue(not x>y)
             self.assertTrue(not x==y)
             self.assertTrue(x!=y)
-            
+
             self.assertTrue(x==x_copy)
             self.assertTrue(x_copy >= x)
             self.assertTrue(x_copy <= x)
-            
+
         #date and time
         date = datetime.date(2005, 3, 23)
         time = datetime.time(2,28,3,99)
@@ -533,13 +532,13 @@ class DatetimeTest(IronPythonTestCase):
         self.assertEqual(x.date(), date)
         #CodePlex Work Item 4860
         self.assertEqual(x.time(), time)
-        
+
         #timetz
         #CodePlex Work Item 4860
         x = datetime.datetime(2005, 3, 23, 2, 28, 3, 99)
         time = datetime.time(2,28,3,99)
         self.assertEqual(x.timetz(), time)
-        
+
         #replace
         x = datetime.datetime(2005, 3, 23, 2, 28, 3, 99)
         y = datetime.datetime(2005, 3, 23, 2, 28, 3, 99)
@@ -551,7 +550,7 @@ class DatetimeTest(IronPythonTestCase):
         z = x.replace(month=7)
         self.assertEqual(y, x)
         self.assertEqual(z.month, 7)
-        
+
         z = x.replace(day=12)
         self.assertEqual(y, x)
         self.assertEqual(z.day, 12)
@@ -567,12 +566,12 @@ class DatetimeTest(IronPythonTestCase):
         z = x.replace(second=25)
         self.assertEqual(y, x)
         self.assertEqual(z.second, 25)
-        
+
         #CodePlex Work Item 4860
         z = x.replace(microsecond=250)
         self.assertEqual(y, x)
         self.assertEqual(z.microsecond, 250)
-        
+
         z = x.replace(year=1000, month=7, day=12, hour=3, minute=5, second=25, microsecond=250)
         self.assertEqual(y, x)
         self.assertEqual(z.year, 1000)
@@ -583,53 +582,53 @@ class DatetimeTest(IronPythonTestCase):
         self.assertEqual(z.second, 25)
         #CodePlex Work Item 4860
         self.assertEqual(z.microsecond, 250)
-        
+
         #astimezone
         #TODO
         #x = datetime.datetime(2005, 3, 23, 2, 28, 3, 99)
         #x.astimezone(...)
-        
+
         #utcoffset
         x = datetime.datetime(2005, 3, 23, 2,28,3,99,None)
         self.assertEqual(x.utcoffset(), None)
-        
+
         #dst
         x = datetime.datetime(2005, 3, 23,2,28,3,99,None)
         self.assertEqual(x.dst(), None)
-        
+
         #tzname
         x = datetime.datetime(2005, 3, 23, 2,28,3,99,None)
         self.assertEqual(x.tzname(), None)
-        
+
         #timetuple
         self.assertEqual(datetime.datetime(2005, 3, 23,2,28,3,99,None).timetuple(), (2005, 3, 23, 2, 28, 3, 2, 82, -1))
-        
+
         #utctimetuple
         self.assertEqual(datetime.datetime(2005, 3, 23,2,28,3,99,None).utctimetuple(), (2005, 3, 23, 2, 28, 3, 2, 82, 0))
-        
+
         #toordinal
         self.assertEqual(datetime.datetime(2005, 3, 23,2,28,3,99,None).toordinal(), 732028)
 
         #weekday
         self.assertEqual(datetime.datetime(2005, 3, 23,2,28,3,99,None).weekday(), 2)
-        
+
         #isocalendar
         x = datetime.datetime(2005, 3, 22,2,28,3,99,None).isocalendar()
         self.assertEqual(x[0], 2005)
         self.assertEqual(x[1], 12)
         self.assertEqual(x[2], 2)
-        
+
         #isoformat
         x = datetime.datetime(2005, 3, 22, 2,28,3,99,None).isoformat()
         self.assertEqual(x, '2005-03-22T02:28:03.000099')
-        
+
         #isoweekday
         self.assertEqual(datetime.datetime(2005, 3, 22, 2,28,3,99,None).isoweekday(), 2)
-        
+
         #ctime
         self.assertEqual(datetime.datetime(2005, 3, 22, 2,28,3,99,None).ctime(), 'Tue Mar 22 02:28:03 2005')
-        
-        
+
+
         #strftime
         x = datetime.datetime(2005, 3, 22, 2,28,3,99,None)
         self.assertEqual(x.strftime("%y-%a-%b"), "05-Tue-Mar")
@@ -640,52 +639,52 @@ class DatetimeTest(IronPythonTestCase):
         self.assertEqual(x.strftime("%H:%M:%S"), "02:28:03")
         #Similar to Merlin Work Item 148470
         self.assertEqual(x.strftime("%a %A %b %B %c %d %H %I %j %m %M %p %S %U %w %W %x %X %y %Y %Z %%"), "Tue Tuesday Mar March 03/22/05 02:28:03 22 02 02 081 03 28 AM 03 12 2 12 03/22/05 02:28:03 05 2005  %")
-    
+
     def test_timedelta(self):
         #CodePlex Work Item 4871
         x = datetime.timedelta(1, 2, 3, 4, 5, 6, 7)
         self.assertEqual(x.days, 50)
         self.assertEqual(x.seconds, 21902)
         self.assertEqual(x.microseconds, 4003)
-        
+
         x = datetime.timedelta(days=1, seconds=2, microseconds=3)
         self.assertEqual(x.days, 1)
         self.assertEqual(x.seconds, 2)
         self.assertEqual(x.microseconds, 3)
-        
+
         x = datetime.timedelta(1, 2, 3)
         self.assertEqual(x.days, 1)
         self.assertEqual(x.seconds, 2)
         self.assertEqual(x.microseconds, 3)
-        
+
         x = datetime.timedelta(1, 2)
         self.assertEqual(x.days, 1)
         self.assertEqual(x.seconds, 2)
         self.assertEqual(x.microseconds, 0)
-        
+
         x = datetime.timedelta(1, 2, 3.14)
         self.assertEqual(x.days, 1)
         self.assertEqual(x.seconds, 2)
         self.assertEqual(x.microseconds, 3)
-        
+
         #CodePlex WorkItem 5132
         x = datetime.timedelta(1, 2, 3.74)
         self.assertEqual(x.days, 1)
         self.assertEqual(x.seconds, 2)
         self.assertEqual(x.microseconds, 4)
-        
+
         #CodePlex Work Item 5149
         x = datetime.timedelta(1, 2.0000003, 3.33)
         self.assertEqual(x.days, 1)
         self.assertEqual(x.seconds, 2)
         self.assertEqual(x.microseconds, 4)
-        
+
         #CodePlex WorkItem 5133
         x = datetime.timedelta(microseconds=-1)
         self.assertEqual(x.days, -1)
         self.assertEqual(x.seconds, 86399)
         self.assertEqual(x.microseconds, 999999)
-        
+
         #CodePlex Work Item 5136
         datetime.timedelta(-99999999, 0, 0) #min
         datetime.timedelta(0, 0, 0)
@@ -693,7 +692,7 @@ class DatetimeTest(IronPythonTestCase):
         datetime.timedelta(999999999, 3600*24-1, 1000000-1) #max
 
         self.assertRaises(OverflowError, datetime.timedelta, -1000000000, 0, 0)
-        
+
         #CodePlex WorkItem 5133
         x = datetime.timedelta(0, -1, 0)
         self.assertEqual(x.days, -1)
@@ -703,29 +702,29 @@ class DatetimeTest(IronPythonTestCase):
         self.assertEqual(x.days, -1)
         self.assertEqual(x.seconds, 3600*24-1)
         self.assertEqual(x.microseconds, 999999)
-        
+
         self.assertRaises(OverflowError, datetime.timedelta, 1000000000, 0, 0)
         self.assertRaises(OverflowError, datetime.timedelta, 999999999, 3600*24, 0)
         self.assertRaises(OverflowError, datetime.timedelta, 999999999, 3600*24-1, 1000000)
-        
+
         #min
         x = datetime.timedelta.min
         self.assertEqual(x.days, -999999999)
         self.assertEqual(x.seconds, 0)
         self.assertEqual(x.microseconds, 0)
-        
+
         #max
         x = datetime.timedelta.max
         self.assertEqual(x.days, 999999999)
         self.assertEqual(x.seconds, 3600*24-1)
         self.assertEqual(x.microseconds, 999999)
-        
+
         #CodePlex Work Item 5136
         x = datetime.timedelta.resolution
         self.assertEqual(x.days, 0)
         self.assertEqual(x.seconds, 0)
         self.assertEqual(x.microseconds, 1)
-        
+
         #--------------------------------------------------------------------------
         #--Test addition
         test_data = { ((37, 28, 686000), (37, 28, 686000)) : (74, 57, 372000),
@@ -738,17 +737,17 @@ class DatetimeTest(IronPythonTestCase):
                     ((37, 28, 686000), (-1, -1, -1)) : (36, 27, 685999),
                     ((-1, -1, -1), (37, 28, 686000)) : (36, 27, 685999),
                     }
-                    
+
         for key, value0 in test_data.iteritems():
             dt1 = datetime.timedelta(*key[1])
             dt0 = datetime.timedelta(*key[0])
-            
+
             x = dt1 + dt0
             self.assertEqual(x.days, value0[0])
             self.assertEqual(x.seconds, value0[1])
             self.assertEqual(x.microseconds, value0[2])
-        
-        
+
+
         #--------------------------------------------------------------------------
         #--Test subtraction
         test_data = { ((37, 28, 686000), (37, 28, 686000)) : ((0, 0, 0),(0, 0, 0)),
@@ -763,47 +762,47 @@ class DatetimeTest(IronPythonTestCase):
         for key, (value0, value1) in test_data.iteritems():
             dt1 = datetime.timedelta(*key[1])
             dt0 = datetime.timedelta(*key[0])
-            
+
             x = dt1 - dt0
             self.assertEqual(x.days, value0[0])
             self.assertEqual(x.seconds, value0[1])
             self.assertEqual(x.microseconds, value0[2])
-            
+
             y = dt0 - dt1
             self.assertEqual(y.days, value1[0])
             self.assertEqual(y.seconds, value1[1])
             self.assertEqual(y.microseconds, value1[2])
-        
+
         #multiply
         x = datetime.timedelta(37, 28, 686000) * 12
         self.assertEqual(x.days, 444)
         self.assertEqual(x.seconds, 344)
         self.assertEqual(x.microseconds, 232000)
-        
+
         #division
         x = datetime.timedelta(37, 28, 686000) // 3
         self.assertEqual(x.days, 12)
         self.assertEqual(x.seconds, 3600*8+9)
         self.assertEqual(x.microseconds, 562000)
-        
+
         #+
         x = datetime.timedelta(37, 28, 686000)
         y = +x
         self.assertTrue(y==x)
-        
+
         #-
         x = datetime.timedelta(37, 28, 686000)
         y = -x
         self.assertEqual(y.days, -38)
         self.assertEqual(y.seconds, 86371)
         self.assertEqual(y.microseconds, 314000)
-        
+
         #absolute
         x = datetime.timedelta(37, 28, 686000)
         self.assertEqual(abs(x), x)
         y = datetime.timedelta(-1, 0, 0)
         self.assertEqual(abs(y), datetime.timedelta(1, 0, 0))
-        
+
         #equality
         x = datetime.timedelta(1, 2, 33)
         y = x
@@ -811,46 +810,46 @@ class DatetimeTest(IronPythonTestCase):
         y = datetime.timedelta(1, 2, 34)
         self.assertTrue(not(x==y))
         self.assertTrue(x==datetime.timedelta(1, 2, 33))
-        
+
         #inequality
         x = datetime.timedelta(1, 2, 33)
         y = None
         self.assertTrue(x!=y)
         y = datetime.timedelta(1, 2, 34)
         self.assertTrue(x!=y)
-        
+
         #ge
         self.assertTrue(datetime.timedelta(1, 2, 33) >= datetime.timedelta(1, 2, 33))
         self.assertTrue(datetime.timedelta(1, 2, 34) >= datetime.timedelta(1, 2, 33))
         self.assertTrue(datetime.timedelta(1, 2, 35) >= datetime.timedelta(1, 2, 33))
         self.assertTrue(not (datetime.timedelta(1, 2, 32) >= datetime.timedelta(1, 2, 33)))
         self.assertTrue(not (datetime.timedelta(1, 2, 31) >= datetime.timedelta(1, 2, 33)))
-        
+
         #le
         self.assertTrue(datetime.timedelta(1, 2, 33) <= datetime.timedelta(1, 2, 33))
         self.assertTrue(datetime.timedelta(1, 2, 33) <= datetime.timedelta(1, 2, 34))
         self.assertTrue(datetime.timedelta(1, 2, 33) <= datetime.timedelta(1, 2, 35))
         self.assertTrue(not (datetime.timedelta(1, 2, 33) <= datetime.timedelta(1, 2, 32)))
         self.assertTrue(not (datetime.timedelta(1, 2, 33) <= datetime.timedelta(1, 2, 31)))
-        
+
         #gt
         self.assertTrue(not (datetime.timedelta(1, 2, 33) > datetime.timedelta(1, 2, 33)))
         self.assertTrue(datetime.timedelta(1, 2, 34) > datetime.timedelta(1, 2, 33))
         self.assertTrue(datetime.timedelta(1, 2, 35) > datetime.timedelta(1, 2, 33))
         self.assertTrue(not (datetime.timedelta(1, 2, 32) > datetime.timedelta(1, 2, 33)))
         self.assertTrue(not (datetime.timedelta(1, 2, 31) > datetime.timedelta(1, 2, 33)))
-        
+
         #lt
         self.assertTrue(not(datetime.timedelta(1, 2, 33) < datetime.timedelta(1, 2, 33)))
         self.assertTrue(datetime.timedelta(1, 2, 33) < datetime.timedelta(1, 2, 34))
         self.assertTrue(datetime.timedelta(1, 2, 33) < datetime.timedelta(1, 2, 35))
         self.assertTrue(not (datetime.timedelta(1, 2, 33) < datetime.timedelta(1, 2, 32)))
         self.assertTrue(not (datetime.timedelta(1, 2, 33) < datetime.timedelta(1, 2, 31)))
-        
+
         #hash
         x = datetime.timedelta(1, 2, 33)
         self.assertTrue(x.__hash__()!=None)
-        
+
         #bool
         self.assertTrue(datetime.timedelta(0, 0, 1))
         self.assertTrue(not(datetime.timedelta(0, 0, 0)))
@@ -862,46 +861,46 @@ class DatetimeTest(IronPythonTestCase):
         self.assertEqual(x.minute, 28)
         self.assertEqual(x.second, 3)
         self.assertEqual(x.microsecond, 99)
-        
+
         x = datetime.time(2,28,3,99,None)
         self.assertEqual(x.hour, 2)
         self.assertEqual(x.minute, 28)
         self.assertEqual(x.second, 3)
         self.assertEqual(x.microsecond, 99)
-        
+
         x = datetime.time(2,28,3,99)
         self.assertEqual(x.hour, 2)
         self.assertEqual(x.minute, 28)
         self.assertEqual(x.second, 3)
         self.assertEqual(x.microsecond, 99)
-        
+
         x = datetime.time(2,28,3)
         self.assertEqual(x.hour, 2)
         self.assertEqual(x.minute, 28)
         self.assertEqual(x.second, 3)
         self.assertEqual(x.microsecond, 0)
-        
+
         x = datetime.time(2,28)
         self.assertEqual(x.hour, 2)
         self.assertEqual(x.minute, 28)
         self.assertEqual(x.second, 0)
         self.assertEqual(x.microsecond, 0)
-        
+
         x = datetime.time(2)
         self.assertEqual(x.hour, 2)
         self.assertEqual(x.minute, 0)
         self.assertEqual(x.second, 0)
         self.assertEqual(x.microsecond, 0)
-        
+
         x = datetime.time()
         self.assertEqual(x.hour, 0)
         self.assertEqual(x.minute, 0)
         self.assertEqual(x.second, 0)
         self.assertEqual(x.microsecond, 0)
-        
+
         datetime.time(0, 0, 0, 0) #min
         datetime.time(23, 59, 59, 999999) #max
-        
+
         #negative cases
         #CodePlex Work Item 5143
         self.assertRaises(ValueError, datetime.time, -1, 0, 0, 0)
@@ -909,7 +908,7 @@ class DatetimeTest(IronPythonTestCase):
         self.assertRaises(ValueError, datetime.time, 0, 0, -1, 0)
         self.assertRaises(ValueError, datetime.time, 0, 0, 0, -1)
         self.assertRaises(ValueError, datetime.time, -10, -10, -10, -10)
-        
+
         #CodePlex Work Item 5143
         self.assertRaises(ValueError, datetime.time, 24, 59, 59, 999999)
         self.assertRaises(ValueError, datetime.time, 23, 60, 59, 999999)
@@ -917,7 +916,7 @@ class DatetimeTest(IronPythonTestCase):
         self.assertRaises(ValueError, datetime.time, 23, 59, 59, 1000000)
         self.assertRaises(ValueError, datetime.time, 24, 60, 60, 1000000)
         self.assertRaises(ValueError, datetime.time, 240, 600, 600, 10000000)
-        
+
         #min
         x = datetime.time.min
         self.assertEqual(x.hour, 0)
@@ -930,12 +929,12 @@ class DatetimeTest(IronPythonTestCase):
         self.assertEqual(x.minute, 59)
         self.assertEqual(x.second, 59)
         self.assertEqual(x.microsecond, 999999)
-        
+
         #resolution
         #CodePlex Work Item 5145
         x = datetime.time.resolution
         self.assertEqual(repr(x), 'datetime.timedelta(0, 0, 1)')
-        
+
         #equality
         x = datetime.time(1, 2, 33, 444)
         y = x
@@ -943,51 +942,51 @@ class DatetimeTest(IronPythonTestCase):
         y = datetime.time(1, 2, 33, 445)
         self.assertTrue(not(x==y))
         self.assertTrue(x==datetime.time(1, 2, 33, 444))
-        
+
         #inequality
         x = datetime.time(1, 2, 33, 444)
         y = None
         self.assertTrue(x!=y)
         y = datetime.time(1, 2, 33, 445)
         self.assertTrue(x!=y)
-        
+
         #ge
         self.assertTrue(datetime.time(1, 2, 33, 444) >= datetime.time(1, 2, 33, 444))
         self.assertTrue(datetime.time(1, 2, 33, 445) >= datetime.time(1, 2, 33, 444))
         self.assertTrue(datetime.time(1, 2, 33, 446) >= datetime.time(1, 2, 33, 444))
         self.assertTrue(not (datetime.time(1, 2, 33, 443) >= datetime.time(1, 2, 33, 444)))
         self.assertTrue(not (datetime.time(1, 2, 33, 442) >= datetime.time(1, 2, 33, 444)))
-        
+
         #le
         self.assertTrue(datetime.time(1, 2, 33, 444) <= datetime.time(1, 2, 33, 444))
         self.assertTrue(datetime.time(1, 2, 33, 444) <= datetime.time(1, 2, 33, 445))
         self.assertTrue(datetime.time(1, 2, 33, 444) <= datetime.time(1, 2, 33, 446))
         self.assertTrue(not (datetime.time(1, 2, 33, 444) <= datetime.time(1, 2, 33, 443)))
         self.assertTrue(not (datetime.time(1, 2, 33, 444) <= datetime.time(1, 2, 33, 442)))
-        
+
         #gt
         self.assertTrue(not (datetime.time(1, 2, 33, 444) > datetime.time(1, 2, 33, 444)))
         self.assertTrue(datetime.time(1, 2, 33, 445) > datetime.time(1, 2, 33, 444))
         self.assertTrue(datetime.time(1, 2, 33, 446) > datetime.time(1, 2, 33, 444))
         self.assertTrue(not (datetime.time(1, 2, 33, 443) > datetime.time(1, 2, 33, 444)))
         self.assertTrue(not (datetime.time(1, 2, 33, 442) > datetime.time(1, 2, 33, 444)))
-        
+
         #lt
         self.assertTrue(not(datetime.time(1, 2, 33, 444) < datetime.time(1, 2, 33, 444)))
         self.assertTrue(datetime.time(1, 2, 33, 444) < datetime.time(1, 2, 33, 445))
         self.assertTrue(datetime.time(1, 2, 33, 444) < datetime.time(1, 2, 33, 446))
         self.assertTrue(not (datetime.time(1, 2, 33, 444) < datetime.time(1, 2, 33, 443)))
         self.assertTrue(not (datetime.time(1, 2, 33, 444) < datetime.time(1, 2, 33, 442)))
-        
+
         #hash
         x = datetime.time(1, 2, 33, 444)
         self.assertTrue(x.__hash__()!=None)
-        
+
         #bool
         self.assertTrue(datetime.time(0, 0, 0, 1))
         #CodePlex Work Item 5139
         self.assertTrue(not (datetime.time(0, 0, 0, 0)))
-        
+
         #replace
         x = datetime.time(1, 2, 33, 444)
         y = datetime.time(1, 2, 33, 444)
@@ -1003,42 +1002,42 @@ class DatetimeTest(IronPythonTestCase):
         z = x.replace(second=25)
         self.assertEqual(y, x)
         self.assertEqual(z.second, 25)
-        
+
         z = x.replace(microsecond=250)
         self.assertEqual(y, x)
         self.assertEqual(z.microsecond, 250)
-        
+
         z = x.replace(hour=3, minute=5, second=25, microsecond=250)
         self.assertEqual(y, x)
         self.assertEqual(z.hour, 3)
         self.assertEqual(z.minute, 5)
         self.assertEqual(z.second, 25)
         self.assertEqual(z.microsecond, 250)
-        
+
         #isoformat
         #CodePlex Work Item 5146
         x = datetime.time(2,28,3,99).isoformat()
         self.assertEqual(x, '02:28:03.000099')
-        
+
         #strftime
         x = datetime.time(13,28,3,99)
         self.assertEqual(x.strftime("%I:%M:%S"), "01:28:03")
         self.assertEqual(x.strftime("%H:%M:%S"), "13:28:03")
-        
+
         #utcoffset
         #CodePlex Work Item 5147
         x = datetime.time(2,28,3,99,None)
         self.assertEqual(x.utcoffset(), None)
-        
+
         #dst
         x = datetime.time(2,28,3,99,None)
         self.assertEqual(x.dst(), None)
-        
+
         #tzname
         #CodePlex Work Item 5148
         x = datetime.time(2,28,3,99,None)
         self.assertEqual(x.tzname(), None)
-    
+
     @skipUnlessIronPython()
     def test_tzinfo(self):
         x = datetime.tzinfo()
@@ -1046,7 +1045,7 @@ class DatetimeTest(IronPythonTestCase):
         self.assertRaises(NotImplementedError, x.dst, None)
         self.assertRaises(NotImplementedError, x.tzname, None)
         self.assertRaises(NotImplementedError, x.fromutc, None)
-    
+
     def test_invariant(self):
         for x in range(0, 10000, 99):
             now = datetime.datetime.now()
@@ -1060,7 +1059,7 @@ class DatetimeTest(IronPythonTestCase):
             for y in [-9, -1, 0, 1, 49, 99]:
                 delta = datetime.timedelta(microseconds= pow10 + y)
                 self.assertEqual(delta * 2, delta + delta)
-                
+
                 delta = datetime.timedelta(microseconds= -pow10 - y)
                 self.assertEqual(delta * 3, delta + delta + delta)
 
@@ -1076,39 +1075,37 @@ class DatetimeTest(IronPythonTestCase):
 
     def test_cp13704(self):
         '''
-        TODO: 
+        TODO:
         - extend this for datetime.date, datetime.time, etc
         - splatted args, keyword args, etc
         '''
         min_args = 3
 
         if not is_cli:
-            self.assertRaisesMessage(TypeError, "Required argument 'year' (pos 1) not found", 
+            self.assertRaisesMessage(TypeError, "Required argument 'year' (pos 1) not found",
                                 datetime.datetime)
-            self.assertRaisesMessage(TypeError, "an integer is required",  
+            self.assertRaisesMessage(TypeError, "an integer is required",
                                 datetime.datetime, None, None)
-            self.assertRaisesMessage(TypeError, "function takes at most 8 arguments (9 given)", 
+            self.assertRaisesMessage(TypeError, "function takes at most 8 arguments (9 given)",
                                 datetime.datetime, None, None, None, None, None, None, None, None, None)
-            self.assertRaisesMessage(TypeError, "function takes at most 8 arguments (10 given)", 
+            self.assertRaisesMessage(TypeError, "function takes at most 8 arguments (10 given)",
                                 datetime.datetime, None, None, None, None, None, None, None, None, None, None)
-            
+
         else: #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=13704
-            self.assertRaisesMessage(TypeError, "function takes at least %d arguments (0 given)" % min_args, 
+            self.assertRaisesMessage(TypeError, "function takes at least %d arguments (0 given)" % min_args,
                                 datetime.datetime)
-            self.assertRaisesMessage(TypeError, "function takes at least %d arguments (2 given)" % min_args, 
+            self.assertRaisesMessage(TypeError, "function takes at least %d arguments (2 given)" % min_args,
                                 datetime.datetime, None, None)
-            self.assertRaisesMessage(TypeError, "function takes at most 8 arguments (9 given)", 
+            self.assertRaisesMessage(TypeError, "function takes at most 8 arguments (9 given)",
                                 datetime.datetime, None, None, None, None, None, None, None, None, None)
-            self.assertRaisesMessage(TypeError, "function takes at most 8 arguments (10 given)", 
+            self.assertRaisesMessage(TypeError, "function takes at most 8 arguments (10 given)",
                                 datetime.datetime, None, None, None, None, None, None, None, None, None, None)
-                           
 
     def test_pickle(self):
         import cPickle
         now = datetime.datetime.now()
         nowstr = cPickle.dumps(now)
         self.assertEqual(now, cPickle.loads(nowstr))
-
 
     def test_datetime_datetime_pickled_by_cpy(self):
         import cPickle
@@ -1120,7 +1117,6 @@ class DatetimeTest(IronPythonTestCase):
         expected_dt    = datetime.datetime(2009, 8, 6, 8, 42, 38, 196000, mytzinfo())
         pickled_cpy_dt = cPickle.loads("cdatetime\ndatetime\np1\n(S'\\x07\\xd9\\x01\\x02\\x03\\x04\\x05\\x00\\x00\\x06'\nc" + __name__ + "\nmytzinfo\np2\n(tRp3\ntRp4\n.")
         self.assertEqual(expected_dt.tzinfo, pickled_cpy_dt.tzinfo)
-
 
     def test_datetime_repr(self):
         self.assertEqual(repr(datetime.datetime(2009, 1, 2, 3, 4, 5, 6, mytzinfo())), "datetime.datetime(2009, 1, 2, 3, 4, 5, 6, tzinfo=hello)")

--- a/Tests/modules/misc/test_future.py
+++ b/Tests/modules/misc/test_future.py
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-
 ##
 ## Test __future__ related areas where __future__ is enabled in the module scope;
 ##
@@ -17,12 +16,12 @@ from iptest import IronPythonTestCase, is_cli, path_modifier, run_test
 assert_code = '''
 def CustomAssert(c):
     if not c: raise AssertionError("Assertion Failed")
-    
+
 '''
 
 code1  = assert_code + '''
-exec "CustomAssert(1/2 == 0.5)"
-exec "from __future__ import division; CustomAssert(1/2 == 0.5)"
+exec("CustomAssert(1/2 == 0.5)")
+exec("from __future__ import division; CustomAssert(1/2 == 0.5)")
 CustomAssert(1/2 == 0.5)
 CustomAssert(eval('1/2') == 0.5)
 '''
@@ -31,8 +30,8 @@ code2 = "from __future__ import division\n" + code1
 
 # this is true if the code is imported as module
 code0 = assert_code + '''
-exec "CustomAssert(1/2 == 0)"
-exec "from __future__ import division; CustomAssert(1/2 == 0.5)"
+exec("CustomAssert(1/2 == 0)")
+exec("from __future__ import division; CustomAssert(1/2 == 0.5)")
 CustomAssert(1/2 == 0)
 CustomAssert(eval('1/2') == 0)
 '''
@@ -45,15 +44,15 @@ class C:
     def __init__(self, selph):
         self.selph = selph
     def check(self):
-        exec "self.selph.assertEqual(1 / 2, 0.5)"
-        exec "from __future__ import division; self.selph.assertEqual(1/2, 0.5)"
+        exec("self.selph.assertEqual(1 / 2, 0.5)")
+        exec("from __future__ import division; self.selph.assertEqual(1/2, 0.5)")
         self.selph.assertEqual(1 / 2, 0.5)
         self.selph.assertEqual(eval("1/2"), 0.5)
 
 # the following are always true in current context
 def always_true(self):
-    exec "self.assertEqual(1 / 2, 0.5)"
-    exec "from __future__ import division; self.assertEqual(1 / 2, 0.5)"
+    exec("self.assertEqual(1 / 2, 0.5)")
+    exec("from __future__ import division; self.assertEqual(1 / 2, 0.5)")
     self.assertEqual(1/2, 0.5)
     self.assertEqual(eval("1/2"), 0.5)
 
@@ -70,7 +69,7 @@ class FutureTest(IronPythonTestCase):
             with path_modifier(self.temporary_dir):
                 for code in (code1, code2) :
                     self.write_to_file(self.tempfile, code)
-                    
+
                     f1(self.tempfile)
                     always_true(self)
                     f2(code, self.tempfile)
@@ -81,14 +80,14 @@ class FutureTest(IronPythonTestCase):
                 ## test import from file
                 for code in (code0, code2):
                     self.write_to_file(self.tempfile, code)
-                    
+
                     import temp_future
                     always_true(self)
                     reloaded_temp_future = reload(temp_future)
                     always_true(self)
         finally:
             self.delete_files(self.tempfile)
-    
+
     def test_class_context(self):
         """carry context over class def"""
         C(self).check()
@@ -101,7 +100,7 @@ class FutureTest(IronPythonTestCase):
         class myfloat(float): pass
         class mycomplex(complex): pass
 
-        l = [2, 10L, (1+2j), 3.4, myint(7), mylong(5), myfloat(2.32), mycomplex(3, 2), True]
+        l = [2, long(10), (1+2j), 3.4, myint(7), mylong(5), myfloat(2.32), mycomplex(3, 2), True]
 
         if is_cli:
             import System
@@ -115,15 +114,15 @@ class FutureTest(IronPythonTestCase):
                     self.fail("True division failed: %r(%s) / %r(%s)" % (a, type(a), b, type(b)))
 
         # check division by zero exceptions for true
-        threes = [ 3, 3L, 3.0 ]
-        zeroes = [ 0, 0L, 0.0 ]
+        threes = [ 3, long(3), 3.0 ]
+        zeroes = [ 0, long(0), 0.0 ]
 
         if is_cli:
             import System
             threes.append(System.Int64.Parse("3"))
             zeroes.append(System.Int64.Parse("0"))
 
-        if is_cli:    
+        if is_cli:
             #Verify true division of a overloaded / operator in a C# class
             self.add_clr_assemblies("operators")
             from Merlin.Testing.Call import AllOpsClass
@@ -143,8 +142,8 @@ class FutureTest(IronPythonTestCase):
 
     def test_builtin_compile(self):
         """built-in compile method when passing flags"""
-        self.assertEqual( eval(compile("2/3", "<string>", "eval", 0, 1), {}), 0)
-        self.assertEqual( eval(compile("2/3", "<string>", "eval", 0), {}), 2/3)
+        self.assertEqual( eval(compile("1/4", "<string>", "eval", 0, 1), {}), 0)
+        self.assertEqual( eval(compile("1/4", "<string>", "eval", 0), {}), 1/4)
 
 run_test(__name__)
 

--- a/Tests/modules/misc/test_math.py
+++ b/Tests/modules/misc/test_math.py
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-
 import itertools
 import math
 import unittest
@@ -18,12 +17,11 @@ class MathTest(IronPythonTestCase):
         self.assertTrue("pypypypypy" == 5 * "py")
         self.assertTrue("pypypypypy" == "py" * 5)
         self.assertTrue("pypypypy" == 2 * "py" * 2)
-        
+
         self.assertTrue(['py', 'py', 'py'] == ['py'] * 3)
         self.assertTrue(['py', 'py', 'py'] == 3 * ['py'])
-        
-        self.assertTrue(['py', 'py', 'py', 'py', 'py', 'py', 'py', 'py', 'py'] == 3 * ['py'] * 3)
 
+        self.assertTrue(['py', 'py', 'py', 'py', 'py', 'py', 'py', 'py', 'py'] == 3 * ['py'] * 3)
 
     def test_misc(self):
         self.assertTrue(3782452410 > 0)
@@ -36,9 +34,9 @@ class MathTest(IronPythonTestCase):
         self.assertEqual(pow(1j, 2), (-1.0+0j))
         self.assertEqual(1+0j, 1)
         self.assertEqual(1+0j, 1.0)
-        self.assertEqual(1+0j, 1L)
-        self.assertEqual((1+1j)/1L, (1+1j))
-        self.assertEqual((1j) + 1L, (1+1j))
+        self.assertEqual(1+0j, long(1))
+        self.assertEqual((1+1j)/long(1), (1+1j))
+        self.assertEqual((1j) + long(1), (1+1j))
         self.assertEqual(0j ** 0, 1)
         self.assertEqual(0j ** 0j, 1)
         self.assertEqual(pow(0j, 0), 1)
@@ -61,17 +59,16 @@ class MathTest(IronPythonTestCase):
         self.assertEqual( 25 % (5+3j), (10-9j))
 
     def test_more_complex(self):
-        self.assertEqual((12+3j)/3L, (4+1j))
-        self.assertEqual(3j - 5L, -5+3j)
+        self.assertEqual((12+3j)/long(3), (4+1j))
+        self.assertEqual(3j - long(5), -5+3j)
         if is_cli: self.assertEqual(3j - Int64(), 3j)
         self.assertRaises(TypeError, (lambda:3j-[]))
         if is_cli: self.assertEqual(pow(5j, Int64()), (1+0j))
-        self.assertEqual(pow(5j, 0L), (1+0j))
+        self.assertEqual(pow(5j, long(0)), (1+0j))
         self.assertRaises(TypeError, (lambda:pow(5j, [])))
         if is_cli: self.assertEqual(5j * Int64(), 0)
-        self.assertEqual(5j * 3L, 15j)
+        self.assertEqual(5j * long(3), 15j)
         self.assertRaises(TypeError, (lambda:(5j*[])))
-
 
     def test_erf(self):
         table = [
@@ -123,7 +120,7 @@ class MathTest(IronPythonTestCase):
             (3.5,  0.9999993),
             (4.0,  1.0000000),
         ]
-        
+
         for x, y in table:
             self.assertAlmostEqual(y, math.erf(x), places=7)
             self.assertAlmostEqual(-y, math.erf(-x), places=7)
@@ -178,7 +175,7 @@ class MathTest(IronPythonTestCase):
             (3.5,  0.0000007),
             (4.0,  0.0000000),
         ]
-        
+
         for x, y in table:
             self.assertAlmostEqual(y, math.erfc(x), places=7)
             self.assertAlmostEqual(2.0 - y, math.erfc(-x), places=7)
@@ -190,7 +187,7 @@ class MathTest(IronPythonTestCase):
                 break
             self.assertAlmostEqual(math.erf(x), -math.erf(-x), places=tolerance)
             self.assertAlmostEqual(math.erfc(x), 2.0 - math.erfc(-x), places=tolerance)
-            
+
             self.assertAlmostEqual(1.0 - math.erf(x), math.erfc(x), places=tolerance)
             self.assertAlmostEqual(1.0 - math.erf(-x), math.erfc(-x), places=tolerance)
             self.assertAlmostEqual(1.0 - math.erfc(x), math.erf(x), places=tolerance)
@@ -227,7 +224,7 @@ class MathTest(IronPythonTestCase):
             self.assertAlmostEqual(math.lgamma(x), math.log(math.gamma(x)), places=tolerance)
             self.assertAlmostEqual(math.lgamma(x*x), math.log(math.gamma(x*x)), places=tolerance)
             self.assertAlmostEqual(math.lgamma(2.0**x), math.log(math.gamma(2.0**x)), places=tolerance)
-            
+
             # Test negative values too, but not integers
             if x % 1.0 != 0.0:
                 self.assertAlmostEqual(math.lgamma(-x), math.log(abs(math.gamma(-x))), places=tolerance)
@@ -255,16 +252,16 @@ class MathTest(IronPythonTestCase):
                     lmod = long(mod)
                     self.assertTrue(type(mod) == int)
                     self.assertTrue(type(lmod) == long)
-        
+
                     ir = pow(i, exp, mod)
                     lr = pow(l, lexp, lmod)
-        
+
                     self.assertEqual(ir, lr)
-                    
-                    for zero in [0, 0L]:
+
+                    for zero in [0, long(0)]:
                         ir = pow(i, zero, mod)
                         lr = pow(l, zero, lmod)
-                        
+
                         if mod > 0:
                             self.assertEqual(ir, 1)
                             self.assertEqual(lr, 1)
@@ -272,11 +269,11 @@ class MathTest(IronPythonTestCase):
                             self.assertEqual(ir, mod+1)
                             self.assertEqual(lr, mod+1)
                 self.assertRaises(ValueError, pow, i, exp, 0)
-                self.assertRaises(ValueError, pow, l, lexp, 0L)
-        
-            
-            for exp in [0, 0L]:
-                for mod in [-1,1,-1L,1L]:
+                self.assertRaises(ValueError, pow, l, lexp, long(0))
+
+
+            for exp in [0, long(0)]:
+                for mod in [-1,1,-long(1),long(1)]:
                     ir = pow(i, exp, mod)
                     lr = pow(l, exp, mod)
                     self.assertEqual(ir, 0)
@@ -288,23 +285,23 @@ class MathTest(IronPythonTestCase):
                 return ("powtest.__pow__", exp, mod)
             def __rpow__(self, exp):
                 return ("powtest.__rpow__", exp)
-        
+
         self.assertEqual(pow(powtest(), 1, 2), ("powtest.__pow__", 1, 2))
         self.assertEqual(pow(powtest(), 3), ("powtest.__pow__", 3, None))
         self.assertEqual(powtest() ** 4, ("powtest.__pow__", 4, None))
         self.assertEqual(5 ** powtest(), ("powtest.__rpow__", 5))
         self.assertEqual(pow(7, powtest()), ("powtest.__rpow__", 7))
         self.assertRaises(TypeError, pow, 1, powtest(), 7)
-        
+
         # Extensible Float tests
         class XFloat(float): pass
-        
+
         self.assertEqual(XFloat(3.14), 3.14)
         self.assertTrue(XFloat(3.14) < 4.0)
         self.assertTrue(XFloat(3.14) > 3.0)
         self.assertTrue(XFloat(3.14) < XFloat(4.0))
         self.assertTrue(XFloat(3.14) > XFloat(3.0))
-        
+
         self.assertTrue(0xabcdef01 + (0xabcdef01<<32)+(0xabcdef01<<64) == 0xabcdef01abcdef01abcdef01)
 
     def test_rounding(self):
@@ -312,14 +309,14 @@ class MathTest(IronPythonTestCase):
         self.assertTrue(round(5.5519) == (6.0))
         self.assertTrue(round(-5.5) == (-6.0))
         self.assertTrue(round(-5.0) == (-5.0))
-        
+
         self.assertTrue(round(-4.5) == (-5.0))
         self.assertTrue(round(-2.5) == (-3.0))
         self.assertTrue(round(-0.5) == (-1.0))
         self.assertTrue(round(0.5) == (1.0))
         self.assertTrue(round(2.5) == (3.0))
         self.assertTrue(round(4.5) == (5.0))
-            
+
         self.assertTrue(round(-4.0) == (-4.0))
         self.assertTrue(round(-3.5) == (-4.0))
         self.assertTrue(round(-3.0) == (-3.0))
@@ -334,7 +331,7 @@ class MathTest(IronPythonTestCase):
         self.assertTrue(round(3.5) == (4.0))
         self.assertTrue(round(4.0) == (4.0))
         self.assertTrue(round(5.0) == (5.0))
-        
+
         # two parameter round overload
         self.assertTrue(round(-4.0, 0) == (-4.0))
         self.assertTrue(round(-3.5, 0) == (-4.0))
@@ -380,7 +377,7 @@ class MathTest(IronPythonTestCase):
             else:
                 self.assertTrue(abs(round(123.41526375, i) - 123.41526375) < 0.0000000001)
                 self.assertTrue(abs(round(-123.41526375, i) - -123.41526375) < 0.0000000001)
-                
+
         self.assertTrue(round(7182930456.0, -1) == 7182930460.0)
         self.assertTrue(round(7182930456.0, -2) == 7182930500.0)
         self.assertTrue(round(7182930456.0, -3) == 7182930000.0)
@@ -415,22 +412,22 @@ class MathTest(IronPythonTestCase):
         z += x
         z += x
         self.assertTrue(y == z)
-        
-        self.assertTrue(1 << 32 == 4294967296L)
+
+        self.assertTrue(1 << 32 == 4294967296)
         self.assertTrue(2 << 32 == (1 << 32) << 1)
         self.assertTrue(((1 << 16) << 16) << 16 == 1 << 48)
-        self.assertTrue(((1 << 16) << 16) << 16 == 281474976710656L)
-        
+        self.assertTrue(((1 << 16) << 16) << 16 == 281474976710656)
+
         for i in [1, 10, 42, 1000000000, 34141235135135135, 13523525234523452345235235234523, 100000000000000000000000000000000000000]:
             self.assertTrue(~i == -i - 1)
-        
+
         self.assertTrue(7 ** 5 == 7*7*7*7*7)
-        self.assertTrue(7L ** 5L == 7L*7L*7L*7L*7L)
-        self.assertTrue(7 ** 5L == 7*7*7*7*7)
-        self.assertTrue(7L ** 5 == 7L*7L*7L*7L*7L)
+        self.assertTrue(long(7) ** long(5) == long(7)*long(7)*long(7)*long(7)*long(7))
+        self.assertTrue(7 ** long(5) == 7*7*7*7*7)
+        self.assertTrue(long(7) ** 5 == long(7)*long(7)*long(7)*long(7)*long(7))
         self.assertTrue(1 ** 735293857239475 == 1)
         self.assertTrue(0 ** 735293857239475 == 0)
-        
+
         self.assertTrue(2 ** 3.0 == 8.0)
         self.assertTrue(2.0 ** 3 == 8.0)
         self.assertTrue(4 ** 0.5 == 2.0)
@@ -484,10 +481,10 @@ class MathTest(IronPythonTestCase):
         self.assertTrue(not ('a' == 20))
         self.assertTrue(not (2.5 == None))
         self.assertTrue(not (20 == (2,3)))
-        
+
         self.assertEqual(long(1234793454934), 1234793454934)
         self.assertEqual(4 ** -2, 0.0625)
-        self.assertEqual(4L ** -2, 0.0625)
+        self.assertEqual(long(4) ** -2, 0.0625)
 
     def test_zero_division(self):
         self.assertRaises(ZeroDivisionError, (lambda: (0 ** -1)))
@@ -495,20 +492,20 @@ class MathTest(IronPythonTestCase):
         self.assertRaises(ZeroDivisionError, (lambda: (0 ** -1.0)))
         self.assertRaises(ZeroDivisionError, (lambda: (0.0 ** -1.0)))
         self.assertRaises(ZeroDivisionError, (lambda: (False ** -1)))
-        self.assertRaises(ZeroDivisionError, (lambda: (0L ** -(2 ** 65))))
+        self.assertRaises(ZeroDivisionError, (lambda: (long(0) ** -(2 ** 65))))
         self.assertRaises(ZeroDivisionError, (lambda: (0j ** -1)))
         self.assertRaises(ZeroDivisionError, (lambda: (0j ** 1j)))
 
     def test_extensible_math(self):
         operators = ['__add__', '__sub__', '__pow__', '__mul__', '__div__', '__floordiv__', '__truediv__', '__mod__']
         opSymbol  = ['+',       '-',       '**',      '*',       '/',       '//',           '/',           '%']
-        
+
         types = []
-        for baseType in [(int, (100,2)), (long, (100L, 2L)), (float, (100.0, 2.0))]:
+        for baseType in [(int, (100,2)), (long, (long(100), long(2))), (float, (100.0, 2.0))]:
         # (complex, (100+0j, 2+0j)) - cpython doesn't call reverse ops for complex ?
             class prototype(baseType[0]):
                 for op in operators:
-                    exec '''def %s(self, other):
+                    exec('''def %s(self, other):
     global opCalled
     opCalled.append('%s')
     return super(self.__class__, self).%s(other)
@@ -516,10 +513,10 @@ class MathTest(IronPythonTestCase):
 def %s(self, other):
     global opCalled
     opCalled.append('%s')
-    return super(self.__class__, self).%s(other)''' % (op, op, op, op[:2] + 'r' + op[2:], op[:2] + 'r' + op[2:], op[:2] + 'r' + op[2:])
-        
+    return super(self.__class__, self).%s(other)''' % (op, op, op, op[:2] + 'r' + op[2:], op[:2] + 'r' + op[2:], op[:2] + 'r' + op[2:]))
+
             types.append( (prototype, baseType[1]) )
-    
+
         global opCalled
         opCalled = []
         for op in opSymbol:
@@ -528,21 +525,21 @@ def %s(self, other):
                     ey = typeInfo[0](typeInfo[1][1])
                     nx = typeInfo[0].__bases__[0](typeInfo[1][0])
                     ny = typeInfo[0].__bases__[0](typeInfo[1][1])
-                                    
+
                     #print 'nx %s ey' % op, type(nx), type(ey)
                     res1 = eval('nx %s ey' % op)
                     res2 = eval('nx %s ny' % op)
                     self.assertEqual(res1, res2)
                     self.assertEqual(len(opCalled), 1)
                     opCalled = []
-                    
+
                     #print 'ex %s ny' % op, type(ex), type(ny)
                     res1 = eval('ex %s ny' % op)
                     res2 = eval('nx %s ny' % op)
                     self.assertEqual(res1, res2)
                     self.assertEqual(len(opCalled), 1)
                     opCalled = []
-                
+
 
     def test_nan(self):
         x  = 1e66666
@@ -553,7 +550,7 @@ def %s(self, other):
         self.assertTrue(not x<x)
         self.assertTrue(not x>x)
         self.assertEqual(cmp(x, x), 0)
-        
+
         y = x/x
         self.assertEqual(y == y, False)
         self.assertEqual(y >= y, False)
@@ -562,7 +559,7 @@ def %s(self, other):
         self.assertEqual(y > y, False)
         self.assertEqual(y < y, False)
         self.assertEqual(cmp(y, y), 0)
-        
+
         self.assertTrue(not x==y)
         self.assertTrue(x!=y)
         self.assertTrue(not x>=y)
@@ -575,7 +572,7 @@ def %s(self, other):
         """logon big ints should work"""
         self.assertEqual(round(math.log10(10 ** 1000), 5), 1000.0)
         self.assertEqual(round(math.log(10 ** 1000), 5), 2302.58509)
-        
+
         self.assertEqual(round(math.log10(18446744073709551615), 5),  19.26592)
         self.assertEqual(round(math.log(18446744073709551615), 5), 44.36142)
 
@@ -584,15 +581,15 @@ def %s(self, other):
 
         self.assertEqual(round(math.log10(18446744073709551614), 5),  19.26592)
         self.assertEqual(round(math.log(18446744073709551614), 5), 44.36142)
-        
+
         # log in a new base
         self.assertEqual(round(math.log(2 ** 1000, 2), 5), 1000.0)
-        
-        self.assertRaises(ValueError, math.log, 0L)
-        self.assertRaises(ValueError, math.log, -1L)
-        self.assertEqual(math.log(2L, 1e666), 0.0)
-        self.assertRaises(ValueError, math.log, 2L, -1e666)
-        self.assertRaises(ZeroDivisionError, math.log, 2L, 1.0)
+
+        self.assertRaises(ValueError, math.log, long(0))
+        self.assertRaises(ValueError, math.log, long(-1))
+        self.assertEqual(math.log(long(2), 1e666), 0.0)
+        self.assertRaises(ValueError, math.log, long(2), -1e666)
+        self.assertRaises(ZeroDivisionError, math.log, long(2), 1.0)
 
         #Make sure that an object is converted to float before being passed into log funcs
         class N(object):
@@ -600,26 +597,25 @@ def %s(self, other):
                 return 10.0
             def __long__(self):
                 return 100
-                
+
         self.assertEqual(round(math.log10(N()), 5),1.0)
         self.assertEqual(round(math.log(N()), 5),2.30259)
 
     def test_log_neg(self):
-        for x in [[2,0], [0,2.0], [0], [0L], [0L, 3.14]]:
+        for x in [[2,0], [0,2.0], [0], [long(0)], [long(0), 3.14]]:
             self.assertRaisesMessage(ValueError, "math domain error",
                                 math.log, *x)
-
 
     def test_math_subclass(self):
         """verify subtypes of float/long work w/ math functions"""
         import math
         class myfloat(float): pass
         class mylong(long): pass
-        
+
         mf = myfloat(1)
         ml = mylong(1)
-        
-        for x in math.log, math.log10, math.log1p, math.asinh, math.acosh, math.atanh, math.factorial, math.trunc, math.isinf:        
+
+        for x in math.log, math.log10, math.log1p, math.asinh, math.acosh, math.atanh, math.factorial, math.trunc, math.isinf:
             try:
                 resf = x(mf)
             except ValueError:
@@ -629,7 +625,7 @@ def %s(self, other):
             except ValueError:
                 resl = None
             self.assertEqual(resf, resl)
-    
+
     def test_float_26(self):
         from_hex_tests = [('1.fffffffffffff7', 1.9999999999999998),
                         ('1.fffffffffffff8', 2.0),
@@ -659,20 +655,20 @@ def %s(self, other):
                         ('0x1.Ap3', 13),
                         ('  0x1.Ap1   ', 3.25),
                         ]
-                        
+
         for string, value in from_hex_tests:
             #print string, value
             self.assertEqual(float.fromhex(string), value)
-        
-        from_hex_errors = [(OverflowError, '1.0p1024'), 
-                        (OverflowError, '1.0p1025'), 
+
+        from_hex_errors = [(OverflowError, '1.0p1024'),
+                        (OverflowError, '1.0p1025'),
                         (OverflowError, '10.0p1023'),
                         (OverflowError, '1.ffffffffffffffp1023'),
-                        (ValueError, 'xxxx'), 
+                        (ValueError, 'xxxx'),
                         (OverflowError, '1.0p99999999999999999999999')]
         for excep, error in from_hex_errors:
             self.assertRaises(excep, float.fromhex, error)
-    
+
 
     def test_float_subclass(self):
         global calledCount
@@ -685,10 +681,10 @@ def %s(self, other):
 
         self.assertRaisesMessage(TypeError, "__float__ returned non-float (type int)", float, MyFloat(1.1))
         self.assertEqual(calledCount, 1)
-        
+
     def test_integer_ratio(self):
-        int_ratio_tests = [ (2.5, (5, 2)), (1.3, (5854679515581645L, 4503599627370496L))]
-        
+        int_ratio_tests = [ (2.5, (5, 2)), (1.3, (5854679515581645, 4503599627370496))]
+
         for flt, res in int_ratio_tests:
             self.assertEqual(flt.as_integer_ratio(), res)
 

--- a/Tests/modules/misc/test_system_namespaces.py
+++ b/Tests/modules/misc/test_system_namespaces.py
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-
 '''
 Ensures we can import from .NET 2.0 namespaces and types
 '''
@@ -210,7 +209,7 @@ def deep_dive(in_name, in_type):
     if is_cli:
         import System
     stuff_list = dir(in_type)
-    
+
     for member in stuff_list:
         member_type = eval("type(%s.%s)" % (in_name, member))
         member_fullname = in_name + "." + member
@@ -218,18 +217,16 @@ def deep_dive(in_name, in_type):
             if member_fullname in broken_types:
                 print "SKIPPING", member_fullname
                 continue
-                        
+
             net_type = Type.GetType(member_fullname)
             #We can only import * from static classes.
             if not net_type or (not (net_type.IsAbstract and net_type.IsSealed) and not net_type.IsEnum):
                 continue
-                
-            print member_fullname
-            exec "from " + member_fullname + " import *"
-            
-            
-            deep_dive(member_fullname, member_type)
 
+            print(member_fullname)
+            exec("from " + member_fullname + " import *")
+
+            deep_dive(member_fullname, member_type)
 
 @unittest.skipIf(is_netcoreapp, 'references are different')
 @skipUnlessIronPython()
@@ -237,5 +234,5 @@ class SystemNamespacesTest(IronPythonTestCase):
     def test_system_deep(self):
         import System
         deep_dive("System", System)
-    
+
 run_test(__name__)

--- a/Tests/modules/misc/test_zlib.py
+++ b/Tests/modules/misc/test_zlib.py
@@ -15,14 +15,14 @@ def create_gzip(text):
     import gzip
     with gzip.open('test_data.gz', 'wb') as f:
         f.write(text)
-    with open('test_data.gz', 'r') as f:
+    with open('test_data.gz', 'rb') as f:
         gzip_compress = f.read()
     return gzip_compress
 
 class ZlibTest(IronPythonTestCase):
     def setUp(self):
         super(ZlibTest, self).setUp()
-        self.text = """
+        self.text = b"""
 Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna.
 Nunc viverra imperdiet enim. Fusce est. Vivamus a tellus.
 Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Proin pharetra nonummy pede. Mauris et orci.
@@ -80,19 +80,19 @@ Curabitur non eros. Nullam hendrerit bibendum justo. Fusce iaculis, est quis lac
                 bufs.append(do.decompress(self.gzip_data[i:i+delta]))
                 self.assertEqual(len(do.unconsumed_tail), 0)
             bufs.append(do.flush())
-            self.assertEqual("".join(bufs), self.text)
+            self.assertEqual(b"".join(bufs), self.text)
 
 
     def test_gzip_with_extra(self):
         """gzip header with extra field"""
         # the file was picked up from boost bug report
-        with open(os.path.join(self.test_dir, 'sample.txt.gz')) as f:
+        with open(os.path.join(self.test_dir, 'sample.txt.gz'), "rb") as f:
             gzipped = f.read()
-        self.assertEqual(zlib.decompress(gzipped, zlib.MAX_WBITS | 16), 'hello there\n')
+        self.assertEqual(zlib.decompress(gzipped, zlib.MAX_WBITS | 16), b'hello there\n')
 
 
     def test_gzip_stream_with_extra(self):
-        with open(os.path.join(self.test_dir, 'sample.txt.gz')) as f:
+        with open(os.path.join(self.test_dir, 'sample.txt.gz'), "rb") as f:
             gzipped = f.read()
         for delta in xrange(1, 25):
             do = zlib.decompressobj(zlib.MAX_WBITS | 16)
@@ -101,6 +101,6 @@ Curabitur non eros. Nullam hendrerit bibendum justo. Fusce iaculis, est quis lac
                 bufs.append(do.decompress(gzipped[i:i+delta]))
                 self.assertEqual(len(do.unconsumed_tail), 0)
             bufs.append(do.flush())
-            self.assertEqual("".join(bufs), 'hello there\n')
+            self.assertEqual(b"".join(bufs), b'hello there\n')
 
 run_test(__name__)


### PR DESCRIPTION
Corresponds to the changes in IronLanguages/ironpython3#528