### PR TITLE
Use py3 compatible syntax in tests

### DIFF
--- a/Tests/modules/io_related/test__bytesio.py
+++ b/Tests/modules/io_related/test__bytesio.py
@@ -10,6 +10,7 @@ import sys
 import unittest
 
 from _io import BytesIO
+
 from iptest import run_test
 
 def bytesio_helper():
@@ -28,131 +29,129 @@ def bytesio_helper():
 class BytesIOTest(unittest.TestCase):
 
     def test__BytesIO___class__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___delattr__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___doc__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___format__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___getattribute__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___hash__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___init__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___iter__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___new__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___reduce__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___reduce_ex__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___repr__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___setattr__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___sizeof__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___str__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO___subclasshook__(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_close(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_closed(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_flush(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_getvalue(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_isatty(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_next(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_read(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_read1(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_readable(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_readinto(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_readline(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_readlines(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_seek(self):
-        # TODO: add cases that seek
         x = BytesIO()
 
         # these should all succeed
         x.seek(0)
-        x.seek(0L)
+        x.seek(long(0))
         x.seek(0, 0)
-        x.seek(0L, 0)
-        x.seek(0, 0L)
-        x.seek(0L, 0L)
+        x.seek(long(0), 0)
+        x.seek(0, long(0))
+        x.seek(long(0), long(0))
 
         # these should all fail
         self.assertRaises(TypeError, x.seek, 0, 0.0)
-        self.assertRaises(TypeError, x.seek, 0L, 0.0)
+        self.assertRaises(TypeError, x.seek, long(0), 0.0)
         self.assertRaises(ValueError, x.seek, 0, 1000)
-        self.assertRaises(ValueError, x.seek, 0L, 1000)
+        self.assertRaises(ValueError, x.seek, long(0), 1000)
         self.assertRaises(OverflowError, x.seek, 0, sys.maxsize+1)
-        self.assertRaises(OverflowError, x.seek, 0L, sys.maxsize+1)
+        self.assertRaises(OverflowError, x.seek, long(0), sys.maxsize+1)
         self.assertRaises(TypeError, x.seek, 0.0)
         self.assertRaises(TypeError, x.seek, 0.0, 0)
         self.assertRaises(OverflowError, x.seek, sys.maxsize+1)
         self.assertRaises(OverflowError, x.seek, sys.maxsize+1, 0)
 
     def test__BytesIO_seekable(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_tell(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_truncate(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_writable(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_write(self):
-        print "TODO"
+        print("TODO")
 
     def test__BytesIO_writelines(self):
-        print "TODO"
-
+        print("TODO")
 
     def test_coverage(self):
         '''
@@ -254,11 +253,11 @@ class BytesIOTest(unittest.TestCase):
                             [('I',),
                             [[],[],[],[],[],[],[],[],[],[]],
                             [0,0,0,0,0,0,0,0,0,0]],
-                            [('I',[1L]),
-                            [[1L],[97L],[25185L],[6513249L],[1684234849L],[1684234849L],[1684234849L],[1684234849L],[1684234849L],[1684234849L]],
+                            [('I',[long(1)]),
+                            [[long(1)],[long(97)],[long(25185)],[long(6513249)],[long(1684234849)],[long(1684234849)],[long(1684234849)],[long(1684234849)],[long(1684234849)],[long(1684234849)]],
                             [0,1,2,3,4,4,4,4,4,4]],
-                            [('I',[1L,999L,47L]),
-                            [[1L,999L,47L],[97L,999L,47L],[25185L,999L,47L],[6513249L,999L,47L],[1684234849L,999L,47L],[1684234849L,869L,47L],[1684234849L,26213L,47L],[1684234849L,6776421L,47L],[1684234849L,1751606885L,47L],[1684234849L,1751606885L,105L]],
+                            [('I',[long(1),long(999),long(47)]),
+                            [[long(1),long(999),long(47)],[long(97),long(999),long(47)],[long(25185),long(999),long(47)],[long(6513249),long(999),long(47)],[long(1684234849),long(999),long(47)],[long(1684234849),long(869),long(47)],[long(1684234849),long(26213),long(47)],[long(1684234849),long(6776421),long(47)],[long(1684234849),long(1751606885),long(47)],[long(1684234849),long(1751606885),long(105)]],
                             [0,1,2,3,4,5,6,7,8,9]],
                             [('l',),
                             [[],[],[],[],[],[],[],[],[],[]],
@@ -278,11 +277,11 @@ class BytesIOTest(unittest.TestCase):
                             [('L',),
                             [[],[],[],[],[],[],[],[],[],[]],
                             [0,0,0,0,0,0,0,0,0,0]],
-                            [('L',[100000000L]),
-                            [[100000000L],[100000097L],[99967585L],[90399329L],[1684234849L],[1684234849L],[1684234849L],[1684234849L],[1684234849L],[1684234849L]],
+                            [('L',[long(100000000)]),
+                            [[long(100000000)],[long(100000097)],[long(99967585)],[long(90399329)],[long(1684234849)],[long(1684234849)],[long(1684234849)],[long(1684234849)],[long(1684234849)],[long(1684234849)]],
                             [0,1,2,3,4,4,4,4,4,4]],
-                            [('L',[1L,99L,47L]),
-                            [[1L,99L,47L],[97L,99L,47L],[25185L,99L,47L],[6513249L,99L,47L],[1684234849L,99L,47L],[1684234849L,101L,47L],[1684234849L,26213L,47L],[1684234849L,6776421L,47L],[1684234849L,1751606885L,47L],[1684234849L,1751606885L,105L]],
+                            [('L',[long(1),long(99),long(47)]),
+                            [[long(1),long(99),long(47)],[long(97),long(99),long(47)],[long(25185),long(99),long(47)],[long(6513249),long(99),long(47)],[long(1684234849),long(99),long(47)],[long(1684234849),long(101),long(47)],[long(1684234849),long(26213),long(47)],[long(1684234849),long(6776421),long(47)],[long(1684234849),long(1751606885),long(47)],[long(1684234849),long(1751606885),long(105)]],
                             [0,1,2,3,4,5,6,7,8,9]],
                             [('f',[]),
                             [[],[],[],[],[],[],[],[],[],[]],

--- a/Tests/modules/io_related/test_binascii.py
+++ b/Tests/modules/io_related/test_binascii.py
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-
 ##
 ## Test the binascii module
 ##
@@ -11,7 +10,6 @@ import binascii
 import unittest
 
 from iptest import run_test, skipUnlessIronPython
-
 
 class BinasciiTest(unittest.TestCase):
     def test_negative(self):

--- a/Tests/modules/io_related/test_io_StringIO.py
+++ b/Tests/modules/io_related/test_io_StringIO.py
@@ -1,17 +1,6 @@
-#####################################################################################
-#
-# Copyright (c) IronPython Team. All rights reserved.
-#
-# This source code is subject to terms and conditions of the Apache License, Version 2.0. A
-# copy of the license can be found in the License.html file at the root of this distribution. If
-# you cannot locate the  Apache License, Version 2.0, please send an email to
-# ironpy@microsoft.com. By using this source code in any fashion, you are agreeing to be bound
-# by the terms of the Apache License, Version 2.0.
-#
-# You must not remove this notice, or any other, from this software.
-#
-#
-#####################################################################################
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
 
 ##
 ## Test the io.StringIO
@@ -20,7 +9,7 @@
 
 import unittest
 
-import io as cStringIO
+import io
 
 from iptest import run_test
 
@@ -97,8 +86,8 @@ class StringIOTest(unittest.TestCase):
     # __iter__, next
     def call_next(self, i):
         self.assertEqual(i.__iter__(), i)
-        self.assertEqual(i.next(), "Line 1\n")
-        self.assertEqual(i.next(), "Line 2\n")
+        self.assertEqual(next(i), "Line 1\n")
+        self.assertEqual(next(i), "Line 2\n")
         self.assertEqual([l for l in i], ["Line 3\n", "Line 4\n", "Line 5"])
         i.close()
         self.assertRaises(ValueError, i.readlines)
@@ -208,16 +197,16 @@ class StringIOTest(unittest.TestCase):
         self.assertEqual(i,i)
 
     def init_StringI(self):
-        return cStringIO.StringIO(text)
+        return io.StringIO(text)
 
     def init_StringO(self):
-        o = cStringIO.StringIO()
+        o = io.StringIO()
         o.write(text)
         o.seek(0)
         return o
 
     def init_emptyStringI(self):
-        return cStringIO.StringIO("")
+        return io.StringIO("")
 
     def test_empty(self):
         i = self.init_emptyStringI()
@@ -302,7 +291,7 @@ class StringIOTest(unittest.TestCase):
     def test_cp8567(self):
         for x in ["", "1", "12", "12345"]:
             for i in [5, 6, 7, 2**8, 100, 2**16-1, 2**16, 2**16, 2**31-2, 2**31-1]:
-                cio = cStringIO.StringIO(x)
+                cio = io.StringIO(x)
                 # make sure it doesn't thorow and it doesn't change seek position
                 cio.truncate(i)
                 self.assertEqual(cio.tell(), 0)
@@ -336,7 +325,7 @@ class StringIOTest(unittest.TestCase):
             t(o)
 
     def test_cp22017(self):
-        m = cStringIO.StringIO()
+        m = io.StringIO()
         m.seek(2)
         m.write("hello!")
         self.assertEqual(m.getvalue(), '\x00\x00hello!')
@@ -346,19 +335,19 @@ class StringIOTest(unittest.TestCase):
     # tests from Jeffrey Bester, cp34683
     def test_read(self):
         # test stringio is readable
-        with cStringIO.StringIO("hello world\r\n") as infile:
+        with io.StringIO("hello world\r\n") as infile:
             self.assertSequenceEqual(infile.readline(), "hello world\r\n")
 
     def test_seekable(self):
         # test stringio is seekable
-        with cStringIO.StringIO("hello") as infile:
+        with io.StringIO("hello") as infile:
             infile.seek(0, 2)
             infile.write(" world\r\n")
             self.assertSequenceEqual(infile.getvalue(), "hello world\r\n")
 
     def test_write(self):
         # test stringio is writable
-        with cStringIO.StringIO() as output_file:
+        with io.StringIO() as output_file:
             output_file.write("hello")
             output_file.write(" world\n")
             self.assertSequenceEqual(output_file.getvalue(), "hello world\n")
@@ -367,9 +356,9 @@ class StringIOTest(unittest.TestCase):
     def test_redirect(self):
         import sys
         stdout_save = sys.stdout
-        capture = cStringIO.StringIO()
+        capture = io.StringIO()
         sys.stdout = capture
-        print "Testing"
+        print("Testing")
         sys.stdout = stdout_save
         self.assertEqual(capture.getvalue(), "Testing\n")
 

--- a/Tests/modules/io_related/test_marshal.py
+++ b/Tests/modules/io_related/test_marshal.py
@@ -2,7 +2,6 @@
 # The .NET Foundation licenses this file to you under the Apache 2.0 License.
 # See the LICENSE file in the project root for more information.
 
-
 import marshal
 import os
 import unittest
@@ -24,8 +23,8 @@ class MarshalTest(IronPythonTestCase):
                     254, -255, 256, 257,
                     65534, 65535, -65536,
                     3.1415926,
-                    
-                    0L,
+
+                    long(0),
                     -1234567890123456789,
                     2**33,
                     [],
@@ -40,18 +39,18 @@ class MarshalTest(IronPythonTestCase):
                     0+1j, 2-3.23j,
                     set(),
                     set(['abc', -5]),
-                    set([1, (2.1, 3L), frozenset([5]), 'x']),
+                    set([1, (2.1, long(3)), frozenset([5]), 'x']),
                     frozenset(),
                     frozenset(['abc', -5]),
-                    frozenset([1, (2.1, 3L), frozenset([5]), 'x'])
+                    frozenset([1, (2.1, long(3)), frozenset([5]), 'x'])
                 ]
-        
+
         if is_cli:
             import System
             objects.extend(
                 [
                 System.Single.Parse('-2345678'),
-                System.Int64.Parse('2345678'),                
+                System.Int64.Parse('2345678'),
                 ])
 
         # dumps / loads
@@ -59,7 +58,7 @@ class MarshalTest(IronPythonTestCase):
             s = marshal.dumps(x)
             x2 = marshal.loads(s)
             self.assertEqual(x, x2)
-            
+
             # on 64-bit the order in set/frozenset isn't the same after dumps/loads
             if (is_cli64 or is_osx) and isinstance(x, (set, frozenset)): continue
 
@@ -75,7 +74,7 @@ class MarshalTest(IronPythonTestCase):
                 x2 = marshal.load(f)
 
             self.assertEqual(x, x2)
-    
+
     def test_buffer(self):
         for s in ['', ' ', 'abc ', 'abcdef']:
             x = marshal.dumps(buffer(s))
@@ -84,7 +83,7 @@ class MarshalTest(IronPythonTestCase):
         for s in ['', ' ', 'abc ', 'abcdef']:
             with open(self.tfn, 'wb') as f:
                 marshal.dump(buffer(s), f)
-            
+
             with open(self.tfn, 'rb') as f:
                 x2 = marshal.load(f)
 
@@ -93,11 +92,11 @@ class MarshalTest(IronPythonTestCase):
     def test_negative(self):
         self.assertRaises(TypeError, marshal.dump, 2, None)
         self.assertRaises(TypeError, marshal.load, '-1', None)
-        
+
         l = [1, 2]
         l.append(l)
         self.assertRaises(ValueError, marshal.dumps, l) ## infinite loop
-        
+
         class my: pass
         self.assertRaises(ValueError, marshal.dumps, my())  ## unmarshallable object
 
@@ -106,11 +105,11 @@ class MarshalTest(IronPythonTestCase):
         l = []
         for i in xrange(10):
             l.append(marshal.dumps({i:i}))
-        
+
         data = ''.join(l)
         with open('tempfile.txt', 'w') as f:
             f.write(data)
-        
+
         with open('tempfile.txt') as f:
             for i in xrange(10):
                 obj = marshal.load(f)
@@ -126,7 +125,7 @@ class MarshalTest(IronPythonTestCase):
         self.assertEqual(marshal.loads(marshal.dumps(['abc', 'abc'], 1)), ['abc', 'abc'])
         self.assertEqual(marshal.loads(marshal.dumps(['abc', 'abc'], 0)), ['abc', 'abc'])
         self.assertEqual(marshal.loads(marshal.dumps(['abc', 'abc', 'abc', 'def', 'def'], 1)), ['abc', 'abc', 'abc', 'def', 'def'])
-    
+
     def test_binary_floats(self):
         self.assertEqual(marshal.dumps(2.0, 2), 'g\x00\x00\x00\x00\x00\x00\x00@')
         self.assertEqual(marshal.dumps(2.0), 'g\x00\x00\x00\x00\x00\x00\x00@')


### PR DESCRIPTION
Corresponds to the changes in IronLanguages/ironpython3#529