### PR TITLE
Fix len to allow long results

### DIFF
--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -1045,8 +1045,8 @@ namespace IronPython.Modules {
             return collection.Count;
         }
 
-        public static int len(object o) {
-            return PythonOps.Length(o);
+        public static object len(object o) {
+            return PythonOps.Length(o, out int res, out BigInteger bigRes) ? res : bigRes;
         }
 
         public static PythonType set {

--- a/Src/IronPython/Modules/Builtin.cs
+++ b/Src/IronPython/Modules/Builtin.cs
@@ -1046,7 +1046,7 @@ namespace IronPython.Modules {
         }
 
         public static object len(object o) {
-            return PythonOps.Length(o, out int res, out BigInteger bigRes) ? res : bigRes;
+            return PythonOps.Length(o, out int res, out BigInteger bigRes) ? (object)res : bigRes;
         }
 
         public static PythonType set {

--- a/Src/IronPython/Runtime/Operations/PythonOps.cs
+++ b/Src/IronPython/Runtime/Operations/PythonOps.cs
@@ -900,29 +900,52 @@ namespace IronPython.Runtime.Operations {
             throw TypeError("'{0}' object cannot be interpreted as an index", PythonTypeOps.GetName(o));
         }
 
-        public static int Length(object o) {
+        private static bool ObjectToInt(object o, out int res, out BigInteger longRes) {
+            if (o is BigInteger bi) {
+                if (!bi.AsInt32(out res)) {
+                    longRes = bi;
+                    return false;
+                }
+            } else if (o is int i) {
+                res = i;
+            } else {
+                res = Converter.ConvertToInt32(o);
+            }
+
+            longRes = default;
+            return true;
+        }
+
+        internal static bool Length(object o, out int res, out BigInteger bigRes) {
             if (o is string s) {
-                return s.Length;
+                res = s.Length;
+                bigRes = default;
+                return true;
             }
 
             if (o is object[] os) {
-                return os.Length;
+                res = os.Length;
+                bigRes = default;
+                return true;
             }
 
-            object len = PythonContext.InvokeUnaryOperator(DefaultContext.Default, UnaryOperators.Length, o, 
+            object len = PythonContext.InvokeUnaryOperator(DefaultContext.Default, UnaryOperators.Length, o,
                 string.Format("object of type '{0}' has no len()", PythonOps.GetPythonTypeName(o)));
 
-            int res;
-            if (len is int) {
-                res = (int)len;
+            if (ObjectToInt(len, out res, out bigRes)) {
+                if (res < 0) throw PythonOps.ValueError("__len__ should return >= 0, got {0}", res);
+                return true;
             } else {
-                res = Converter.ConvertToInt32(len);
+                if (bigRes < 0) throw PythonOps.ValueError("__len__ should return >= 0, got {0}", bigRes);
+                return false;
             }
+        }
 
-            if (res < 0) {
-                throw PythonOps.ValueError("__len__ should return >= 0, got {0}", res);
+        public static int Length(object o) {
+            if (Length(o, out int res, out _)) {
+                return res;
             }
-            return res;
+            throw new OverflowException();
         }
 
         public static object CallWithContext(CodeContext/*!*/ context, object func, params object[] args) {

--- a/Src/IronPython/Runtime/Slice.cs
+++ b/Src/IronPython/Runtime/Slice.cs
@@ -118,44 +118,6 @@ namespace IronPython.Runtime {
             stop = stop < 0 ? 0 : stop > size ? size : stop;
         }
 
-        /// <summary>
-        /// Gets the indices for the deprecated __getslice__, __setslice__, __delslice__ functions
-        /// 
-        /// This form is deprecated in favor of using __getitem__ w/ a slice object as an index.  This
-        /// form also has subtly different mechanisms for fixing the slice index before calling the function.
-        /// 
-        /// If an index is negative and __len__ is not defined on the object than an AttributeError
-        /// is raised.
-        /// </summary>
-        internal void DeprecatedFixed(object self, out int newStart, out int newStop) {
-            bool calcedLength = false;  // only call __len__ once, even if we need it twice
-            int length = 0;
-
-            if (_start != null) {
-                newStart = Converter.ConvertToIndex(_start);
-                if (newStart < 0) {
-                    calcedLength = true;
-                    length = PythonOps.Length(self);
-
-                    newStart += length;
-                }
-            } else {
-                newStart = 0;
-            }
-
-            if (_stop != null) {
-                newStop = Converter.ConvertToIndex(_stop);
-                if (newStop < 0) {
-                    if (!calcedLength) length = PythonOps.Length(self);
-
-                    newStop += length;
-                }
-            } else {
-                newStop = Int32.MaxValue;
-            }
-
-        }
-
         internal delegate void SliceAssign(int index, object value);
 
         internal void DoSliceAssign(SliceAssign assign, int size, object value) {

--- a/Tests/test_builtinfunc.py
+++ b/Tests/test_builtinfunc.py
@@ -538,6 +538,12 @@ class BuiltinsTest2(IronPythonTestCase):
 
         self.assertRaises(TypeError, len, foo())
 
+        # ensure len doesn't fail when __len__ returns a long
+        class LongLength(object):
+            def __len__(self): return 11111111111111111
+
+        self.assertEqual(len(LongLength()), 11111111111111111)
+
     def test_int_ctor(self):
         self.assertEqual(int('0x10', 16), 16)
         self.assertEqual(int('0X10', 16), 16)


### PR DESCRIPTION
Allows the following (which currently throws):
```Python
class LongLength(object):
    def __len__(self): return 11111111111111111

assert len(LongLength()) == 11111111111111111
```