### PR TITLE
Allow mmap with length > int.MaxValue on 64-bit systems

### DIFF
--- a/Src/IronPython.Modules/mmap.cs
+++ b/Src/IronPython.Modules/mmap.cs
@@ -136,7 +136,7 @@ namespace IronPython.Modules {
                 if (offset < 0) {
                     throw PythonOps.OverflowError("memory mapped offset must be positive");
                 }
-                if (length > SysModule.maxsize) {
+                if (IntPtr.Size == 4 && length > int.MaxValue) {
                     throw PythonOps.OverflowError("cannot fit 'long' into an index-sized integer");
                 }
 


### PR DESCRIPTION
This currently fails on 64-bit systems:
```Python
import mmap
f = open("somebigfile", "rb")
mmap.mmap(f.fileno(), 2147483648, access=mmap.ACCESS_READ)
```