### PR TITLE
Don't throw on missing encode/decode errors mode

### DIFF
--- a/Src/IronPython/Runtime/ByteArray.cs
+++ b/Src/IronPython/Runtime/ByteArray.cs
@@ -255,7 +255,7 @@ namespace IronPython.Runtime {
             }
         }
         
-        public string decode(CodeContext/*!*/ context, [Optional]object encoding, [DefaultParameterValue("strict")]string errors) {
+        public string decode(CodeContext/*!*/ context, [Optional]object encoding, [DefaultParameterValue("strict")][NotNull]string errors) {
             return StringOps.decode(context, _bytes.MakeString(), encoding, errors);
         }
 


### PR DESCRIPTION
..unless an error is encountered. Fix backported from ipy3 (https://github.com/IronLanguages/ironpython3/pull/535). Resolves a failure in `urllib3`.