### PR TITLE
Fix intermittent pip failure

### DIFF
--- a/Src/IronPython.Modules/bz2/BZ2File.cs
+++ b/Src/IronPython.Modules/bz2/BZ2File.cs
@@ -60,7 +60,7 @@ is given, must be a number between 1 and 9.
                         this.bz2Stream = new BZip2OutputStream(underlyingStream);
                     }
                 } else {
-                    this.bz2Stream = new BZip2InputStream(File.OpenRead(filename));
+                    this.bz2Stream = new BZip2InputStream(File.OpenRead(filename), lazyInitialize: true);
                 }
 
                 this.__init__(bz2Stream, pythonContext.DefaultEncoding, filename, mode);
@@ -156,6 +156,7 @@ the operation may be extremely slow.
 Return the current file position, an integer (may be a long integer).
 ")]
             public new object tell() {
+                if (base._stream is BZip2InputStream bZip2InputStream && !bZip2InputStream.Initialized) return 0; // hack to make tarfile.bz2open happy
                 throw new NotImplementedException();
 
                 //if (this.closed) throw PythonOps.ValueError("I/O operation on closed file");

--- a/Src/IronPython.Modules/bz2/dotnetzip/BZip2/BZip2InputStream.cs
+++ b/Src/IronPython.Modules/bz2/dotnetzip/BZip2/BZip2InputStream.cs
@@ -129,8 +129,7 @@ namespace Ionic.BZip2
         /// </remarks>
         /// <param name='input'>The stream from which to read compressed data</param>
         public BZip2InputStream(Stream input)
-            : this(input, false)
-        {}
+            : this(input, false) { }
 
 
         /// <summary>
@@ -169,12 +168,14 @@ namespace Ionic.BZip2
         ///   </code>
         /// </example>
         public BZip2InputStream(Stream input, bool leaveOpen)
-            : base()
-        {
+            : this(input, leaveOpen: leaveOpen, lazyInitialize: false) { }
+
+        internal BZip2InputStream(Stream input, bool leaveOpen = false, bool lazyInitialize = false)
+            : base() {
 
             this.input = input;
             this._leaveOpen = leaveOpen;
-            init();
+            if (!lazyInitialize) init();
         }
 
         /// <summary>
@@ -200,6 +201,8 @@ namespace Ionic.BZip2
         /// <returns>the number of bytes actually read</returns>
         public override int Read(byte[] buffer, int offset, int count)
         {
+            init();
+
             if (offset < 0)
                 throw new IndexOutOfRangeException(String.Format("offset ({0}) must be > 0", offset));
 
@@ -246,6 +249,8 @@ namespace Ionic.BZip2
         /// <returns>the byte read from the stream, or -1 if EOF</returns>
         public override int ReadByte()
         {
+            init();
+
             int retChar = this.currentChar;
             totalBytesRead++;
             switch (this.currentState)
@@ -429,8 +434,12 @@ namespace Ionic.BZip2
             base.Dispose(disposing);
         }
 
+        internal bool Initialized { get; private set; }
+
         void init()
         {
+            if (Initialized) return;
+
             if (null == this.input)
                 throw new IOException("No input Stream");
 
@@ -451,6 +460,8 @@ namespace Ionic.BZip2
 
             InitBlock();
             SetupBlock();
+
+            Initialized = true;
         }
 
 

--- a/Tests/test_bz2.py
+++ b/Tests/test_bz2.py
@@ -1,0 +1,19 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information.
+
+import bz2
+import unittest
+
+from iptest import run_test
+
+class BZ2Test(unittest.TestCase):
+    def test_bz2file(self):
+        """https://github.com/IronLanguages/ironpython2/pull/739"""
+        
+        # BZ2File should not fail on invalid files, only on read
+        with bz2.BZ2File(__file__, 'r') as f:
+            with self.assertRaises(IOError):
+                f.read()
+
+run_test(__name__)


### PR DESCRIPTION
`pip` calls `tarfile.open` which will attempt to open as `gz`, `bz2` or `tar`. It creates a dictionary which depending on the hashing can be ordered differently (in particular on .NET Core which randomizes hashing). Because of this `bz2` is sometimes tried before `gz` and incorrectly fails on the `bz2.BZ2File`. The call to `bz2.BZ2File` should create a file object and only fail once `read` is called.

This changes `BZ2File` to lazily initialize the underlying `BZip2InputStream` and avoid failure on invalid files.

Note: the source changes do not need to be ported to IronPython 3 since `bz2.BZ2File` is implemented in Python, but we should consider adding the test.