### PR TITLE
Use Mono.Unix for .NET Core runtime

### DIFF
--- a/Src/IronPython.Modules/IronPython.Modules.csproj
+++ b/Src/IronPython.Modules/IronPython.Modules.csproj
@@ -14,7 +14,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup Condition=" '$(IsFullFramework)' != 'true' ">
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/IronPython/IronPython.csproj
+++ b/Src/IronPython/IronPython.csproj
@@ -27,7 +27,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup Condition=" '$(IsFullFramework)' != 'true' ">
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This brings in support for running on Apple Silicon on macOS, as well as iOS, android, maccatalyst, etc.

Fixes #795