### PR TITLE
Don't list extension methods multiple times.

### DIFF
--- a/Src/IronPython/Runtime/Binding/PythonExtensionBinder.cs
+++ b/Src/IronPython/Runtime/Binding/PythonExtensionBinder.cs
@@ -24,7 +24,7 @@ namespace IronPython.Runtime.Binding {
         public override MemberGroup GetMember(MemberRequestKind actionKind, Type type, string name) {
             var res = base.GetMember(actionKind, type, name);
             if (res.Count == 0) {
-                List<MemberTracker> trackers = new List<MemberTracker>();
+                HashSet<MemberTracker> trackers = new HashSet<MemberTracker>();
 
                 foreach (var method in _extMethodSet.GetExtensionMethods(name)) {
                     var parameters = method.GetParameters();
@@ -35,11 +35,11 @@ namespace IronPython.Runtime.Binding {
                     var paramType = parameters[0].ParameterType;
 
                     if (IsApplicableExtensionMethod(type, paramType)) {
-                        trackers.Add(MemberTracker.FromMemberInfo(method, paramType));
+                        (trackers ??= new HashSet<MemberTracker>()).Add(MemberTracker.FromMemberInfo(method, paramType));
                     }
                 }
 
-                if (trackers.Count > 0) {
+                if (trackers is not null) {
                     return new MemberGroup(trackers.ToArray());
                 }
             }

--- a/Src/IronPython/Runtime/ExtensionMethodSet.cs
+++ b/Src/IronPython/Runtime/ExtensionMethodSet.cs
@@ -176,15 +176,18 @@ namespace IronPython.Runtime {
             lock (this) {
                 EnsureLoaded();
 
+                var yieldedMethods = new HashSet<MethodInfo>();
+
                 foreach (var keyValue in _loadedAssemblies) {
                     AssemblyLoadInfo info = keyValue.Value;
 
                     Debug.Assert(info.Types != null);
                     foreach (var type in info.Types) {
-                        List<MethodInfo> methods;
-                        if (type.ExtensionMethods.TryGetValue(name, out methods)) {
+                        if (type.ExtensionMethods.TryGetValue(name, out var methods)) {
                             foreach (var method in methods) {
-                                yield return method;
+                                if (yieldedMethods.Add(method)) {
+                                    yield return method;
+                                }
                             }
                         }
                     }

--- a/Src/IronPython/Runtime/ExtensionMethodSet.cs
+++ b/Src/IronPython/Runtime/ExtensionMethodSet.cs
@@ -176,18 +176,15 @@ namespace IronPython.Runtime {
             lock (this) {
                 EnsureLoaded();
 
-                var yieldedMethods = new HashSet<MethodInfo>();
-
                 foreach (var keyValue in _loadedAssemblies) {
                     AssemblyLoadInfo info = keyValue.Value;
 
                     Debug.Assert(info.Types != null);
                     foreach (var type in info.Types) {
-                        if (type.ExtensionMethods.TryGetValue(name, out var methods)) {
+                        List<MethodInfo> methods;
+                        if (type.ExtensionMethods.TryGetValue(name, out methods)) {
                             foreach (var method in methods) {
-                                if (yieldedMethods.Add(method)) {
-                                    yield return method;
-                                }
+                                yield return method;
                             }
                         }
                     }


### PR DESCRIPTION
This is a copy of the changes from @slozier in ironpython3 https://github.com/IronLanguages/ironpython3/pull/1620
This fixes the same issue in ironpython2 https://github.com/IronLanguages/ironpython2/issues/810