### PR TITLE
Port fix for .NET 9 from IronLanguages/ironpython3#1807 to ironpython2

### DIFF
--- a/Src/IronPython/Runtime/Types/NewTypeMaker.cs
+++ b/Src/IronPython/Runtime/Types/NewTypeMaker.cs
@@ -540,6 +540,7 @@ namespace IronPython.Runtime.Types {
             ImplementInterface(typeof(ICustomTypeDescriptor));
 
             foreach (MethodInfo m in typeof(ICustomTypeDescriptor).GetMethods()) {
+                if (!m.IsAbstract) continue;
                 ImplementCTDOverride(m);
             }
         }


### PR DESCRIPTION
Latest IronPython2 does not work on .NET 9. This fix comes from IronLanguages/ironpython3#1807 specifically: https://github.com/IronLanguages/ironpython3/pull/1807/commits/9c2e61c49c4ffcea367c9566e24f5ded8a06dd9d

Worth noting that IronPython2 does not build using the script in its current state, but can be built after updating DLR to v1.3.2 and applying attached patches to IronPython2 and DLR. 
[patches.zip](https://github.com/user-attachments/files/18359880/patches.zip)

Patches mostly disable analyzers and audits, so probably shouldn't be merged to master but might be useful to anyone trying to build it from source.
